### PR TITLE
Sign Windows release assets during release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,12 +9,20 @@ env:
   DOTNET_CLI_TELEMETRY_OPTOUT: true
 
 jobs:
-  release:
+  prepare-release:
     runs-on: ubuntu-latest
 
     permissions:
-      contents: write
+      contents: read
       actions: read
+
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      ci_run_id: ${{ steps.version.outputs.ci_run_id }}
+      ci_head_sha: ${{ steps.version.outputs.ci_head_sha }}
+      state_json: ${{ steps.version.outputs.state_json }}
+      is_prerelease: ${{ steps.version.outputs.is_prerelease }}
+      phase: ${{ steps.version.outputs.phase }}
 
     steps:
       - name: Checkout
@@ -129,6 +137,133 @@ jobs:
             exit 1
           fi
 
+      - name: Upload unsigned release bundle
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: release-unsigned-bundle
+          path: ./artifacts/*
+          retention-days: 7
+
+  sign-windows:
+    runs-on: windows-2022
+    needs: prepare-release
+    environment: Production
+
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+
+      - name: Download unsigned release bundle
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          name: release-unsigned-bundle
+          path: ./artifacts/bundle
+
+      - name: Expand Windows release assets
+        shell: pwsh
+        run: ./scripts/Expand-WindowsReleaseAssets.ps1 -BundleDirectory './artifacts/bundle' -WorkingDirectory './artifacts/windows-assets'
+
+      - name: Azure login
+        uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Sign Windows executables
+        uses: azure/artifact-signing-action@db7a3a6bd3912025c705162fb7475389f5b69ec6
+        with:
+          endpoint: ${{ secrets.AZURE_SIGNING_ENDPOINT }}
+          signing-account-name: ${{ secrets.AZURE_SIGNING_ACCOUNT }}
+          certificate-profile-name: ${{ secrets.AZURE_CERT_PROFILE }}
+          files-folder: ${{ github.workspace }}\artifacts\windows-assets
+          files-folder-filter: kusto.exe
+          files-folder-recurse: true
+          file-digest: SHA256
+          timestamp-rfc3161: http://timestamp.acs.microsoft.com
+          timestamp-digest: SHA256
+          exclude-environment-credential: true
+          exclude-workload-identity-credential: true
+          exclude-managed-identity-credential: true
+          exclude-shared-token-cache-credential: true
+          exclude-visual-studio-credential: true
+          exclude-visual-studio-code-credential: true
+          exclude-azure-cli-credential: false
+          exclude-azure-powershell-credential: true
+          exclude-azure-developer-cli-credential: true
+          exclude-interactive-browser-credential: true
+
+      - name: Repack signed Windows assets
+        shell: pwsh
+        run: ./scripts/Compress-WindowsReleaseAssets.ps1 -WorkingDirectory './artifacts/windows-assets' -OutputDirectory './artifacts/signed-windows-assets'
+
+      - name: Upload signed Windows assets
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: release-signed-windows-assets
+          path: ./artifacts/signed-windows-assets/*
+          retention-days: 7
+
+  publish-release:
+    runs-on: ubuntu-latest
+    needs: [prepare-release, sign-windows]
+
+    permissions:
+      contents: write
+      actions: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Download unsigned release bundle
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          name: release-unsigned-bundle
+          path: ./artifacts/release
+
+      - name: Download signed Windows assets
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          name: release-signed-windows-assets
+          path: ./artifacts/signed-windows-assets
+
+      - name: Overlay signed Windows assets
+        shell: pwsh
+        run: Copy-Item './artifacts/signed-windows-assets/*' './artifacts/release' -Force
+
+      - name: Regenerate release metadata
+        shell: pwsh
+        run: ./scripts/Update-ReleaseBundleMetadata.ps1 -BundleDirectory './artifacts/release'
+
+      - name: Verify updated release metadata
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          EXPECTED_VERSION='${{ needs.prepare-release.outputs.version }}'
+          METADATA_FILE='./artifacts/release/release-metadata.json'
+
+          if [ ! -f "$METADATA_FILE" ]; then
+            echo "::error::Missing release metadata file."
+            exit 1
+          fi
+
+          ACTUAL_VERSION=$(jq -r '.version' "$METADATA_FILE")
+          if [ "$ACTUAL_VERSION" != "$EXPECTED_VERSION" ]; then
+            echo "::error::Release metadata version mismatch. Expected '$EXPECTED_VERSION' but found '$ACTUAL_VERSION'."
+            exit 1
+          fi
+
       - name: Create GitHub release
         id: create_release
         env:
@@ -137,8 +272,8 @@ jobs:
         run: |
           set -euo pipefail
 
-          VERSION='${{ steps.version.outputs.version }}'
-          IS_PRERELEASE='${{ steps.version.outputs.is_prerelease }}'
+          VERSION='${{ needs.prepare-release.outputs.version }}'
+          IS_PRERELEASE='${{ needs.prepare-release.outputs.is_prerelease }}'
           PRERELEASE_FLAG=()
 
           if [ "$IS_PRERELEASE" = "true" ]; then
@@ -162,21 +297,20 @@ jobs:
 
           Native release assets for Windows, Linux, and macOS.
 
-          - Windows assets are shaped for future WinGet automation.
           - checksums are included in \`checksums.txt\`.
           - release metadata is included in \`release-metadata.json\`." \
-            ./artifacts/*
+            ./artifacts/release/*
 
       - name: Advance version state
         if: steps.create_release.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
-          STATE_JSON: ${{ steps.version.outputs.state_json }}
+          STATE_JSON: ${{ needs.prepare-release.outputs.state_json }}
         shell: bash
         run: |
           set -euo pipefail
 
-          VERSION='${{ steps.version.outputs.version }}'
+          VERSION='${{ needs.prepare-release.outputs.version }}'
           NEW_STATE_JSON=$(dotnet scripts/version.cs advance --state "$STATE_JSON" --shipped-version "$VERSION")
           VERSIONS_JSON=$(dotnet scripts/version.cs calculate --state "$NEW_STATE_JSON")
           NEXT_DEV_VERSION=$(echo "$VERSIONS_JSON" | jq -r '.devVersion')

--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ The repository includes four GitHub Actions workflows:
 
 - `pr.yml` - restore/build/test validation for pull requests across Ubuntu, Windows, and macOS
 - `ci.yml` - version calculation, build/test validation, native asset publishing, and dev draft release updates on `main`
-- `release.yml` - manual promotion of the prebuilt RC bundle into a GitHub release without rebuilding
+- `release.yml` - manual promotion of the prebuilt RC bundle into a GitHub release, including Windows executable signing, without rebuilding
 - `bump-version.yml` - manual semantic-version / phase transitions for `pre`, `rc`, and `rtm`
 
 Version state is stored in the body of the draft `dev` release so CI can calculate the next development and release-candidate versions without committing version files into the repo.
@@ -241,12 +241,12 @@ Version state is stored in the body of the draft `dev` release so CI can calcula
 1. Open a pull request and let `pr.yml` validate restore/build/test behavior.
 2. Merge to `main`, which lets `ci.yml` calculate versions, publish native assets, and refresh the draft `dev` release.
 3. When you want to move between `pre`, `rc`, or `rtm`, run `bump-version.yml`.
-4. When the RC bundle is the one you want to ship, run `release.yml` to promote those already-built artifacts into the GitHub release.
+4. When the RC bundle is the one you want to ship, run `release.yml` to sign the Windows executables and promote those already-built artifacts into the GitHub release.
 5. The next push to `main` refreshes the draft `dev` release for ongoing development.
 
 ## Native release asset layout
 
-CI publishes native assets for:
+CI publishes unsigned native assets for:
 
 - `win-x64`
 - `win-arm64`
@@ -261,6 +261,7 @@ Release assets are intentionally shaped for stable download URLs and easy platfo
 - Linux/macOS: tarballs such as `kusto-linux-x64.tar.gz`
 - Archive contents: `kusto.exe` on Windows, `kusto` on Linux/macOS, plus `LICENSE`
 - Bundles always include `checksums.txt` and `release-metadata.json`
+- `release.yml` re-signs the Windows archives before publishing the final GitHub release, leaving Linux and macOS assets untouched
 
 If you want to generate the same release-shaped outputs locally, use the helper scripts instead of calling `dotnet publish` directly:
 

--- a/scripts/Compress-WindowsReleaseAssets.ps1
+++ b/scripts/Compress-WindowsReleaseAssets.ps1
@@ -1,0 +1,57 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [string]$WorkingDirectory,
+
+    [Parameter(Mandatory)]
+    [string]$OutputDirectory
+)
+
+$ErrorActionPreference = 'Stop'
+
+$workingDirectory = [System.IO.Path]::GetFullPath($WorkingDirectory)
+$outputDirectory = [System.IO.Path]::GetFullPath($OutputDirectory)
+$manifestPath = Join-Path $workingDirectory 'windows-assets-manifest.json'
+
+if (-not (Test-Path $manifestPath))
+{
+    throw "Windows asset manifest '$manifestPath' was not found."
+}
+
+$manifestEntries = @(Get-Content -Path $manifestPath -Raw | ConvertFrom-Json)
+if ($manifestEntries.Count -eq 0)
+{
+    throw "Windows asset manifest '$manifestPath' did not contain any entries."
+}
+
+New-Item -ItemType Directory -Path $outputDirectory -Force | Out-Null
+Add-Type -AssemblyName System.IO.Compression.FileSystem
+
+foreach ($entry in $manifestEntries)
+{
+    $stagingDirectory = [System.IO.Path]::GetFullPath($entry.stagingDirectory)
+    if (-not (Test-Path $stagingDirectory))
+    {
+        throw "Staging directory '$stagingDirectory' was not found."
+    }
+
+    $binaryPath = Join-Path $stagingDirectory 'kusto.exe'
+    if (-not (Test-Path $binaryPath))
+    {
+        throw "Staging directory '$stagingDirectory' does not contain 'kusto.exe'."
+    }
+
+    $licensePath = Join-Path $stagingDirectory 'LICENSE'
+    if (-not (Test-Path $licensePath))
+    {
+        throw "Staging directory '$stagingDirectory' does not contain 'LICENSE'."
+    }
+
+    $archivePath = Join-Path $outputDirectory $entry.assetName
+    if (Test-Path $archivePath)
+    {
+        Remove-Item $archivePath -Force
+    }
+
+    [System.IO.Compression.ZipFile]::CreateFromDirectory($stagingDirectory, $archivePath)
+}

--- a/scripts/Expand-WindowsReleaseAssets.ps1
+++ b/scripts/Expand-WindowsReleaseAssets.ps1
@@ -1,0 +1,77 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [string]$BundleDirectory,
+
+    [Parameter(Mandatory)]
+    [string]$WorkingDirectory
+)
+
+$ErrorActionPreference = 'Stop'
+
+$bundleDirectory = [System.IO.Path]::GetFullPath($BundleDirectory)
+$workingDirectory = [System.IO.Path]::GetFullPath($WorkingDirectory)
+$metadataPath = Join-Path $bundleDirectory 'release-metadata.json'
+
+if (-not (Test-Path $bundleDirectory))
+{
+    throw "Bundle directory '$bundleDirectory' was not found."
+}
+
+if (-not (Test-Path $metadataPath))
+{
+    throw "Release metadata file '$metadataPath' was not found."
+}
+
+$metadata = Get-Content -Path $metadataPath -Raw | ConvertFrom-Json
+$windowsAssets = @($metadata.windowsAssets)
+if ($windowsAssets.Count -eq 0)
+{
+    $windowsAssets = @($metadata.assets | Where-Object { $_.platform -eq 'win' })
+}
+
+if ($windowsAssets.Count -eq 0)
+{
+    throw "No Windows assets were found in '$metadataPath'."
+}
+
+New-Item -ItemType Directory -Path $workingDirectory -Force | Out-Null
+$manifestEntries = @()
+
+foreach ($asset in $windowsAssets)
+{
+    if ([string]::IsNullOrWhiteSpace($asset.runtimeIdentifier))
+    {
+        throw "Windows asset '$($asset.name)' is missing a runtimeIdentifier."
+    }
+
+    $archivePath = Join-Path $bundleDirectory $asset.name
+    if (-not (Test-Path $archivePath))
+    {
+        throw "Archive '$archivePath' referenced in release metadata was not found."
+    }
+
+    $assetDirectory = Join-Path $workingDirectory $asset.runtimeIdentifier
+    if (Test-Path $assetDirectory)
+    {
+        Remove-Item $assetDirectory -Recurse -Force
+    }
+
+    New-Item -ItemType Directory -Path $assetDirectory -Force | Out-Null
+    Expand-Archive -Path $archivePath -DestinationPath $assetDirectory -Force
+
+    $binaryPath = Join-Path $assetDirectory 'kusto.exe'
+    if (-not (Test-Path $binaryPath))
+    {
+        throw "Expanded Windows asset '$($asset.name)' did not contain 'kusto.exe'."
+    }
+
+    $manifestEntries += [ordered]@{
+        assetName = $asset.name
+        runtimeIdentifier = $asset.runtimeIdentifier
+        stagingDirectory = $assetDirectory
+    }
+}
+
+$manifestPath = Join-Path $workingDirectory 'windows-assets-manifest.json'
+$manifestEntries | ConvertTo-Json -Depth 5 | Set-Content -Path $manifestPath

--- a/scripts/Update-ReleaseBundleMetadata.ps1
+++ b/scripts/Update-ReleaseBundleMetadata.ps1
@@ -1,0 +1,59 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [string]$BundleDirectory
+)
+
+$ErrorActionPreference = 'Stop'
+
+$bundleDirectory = [System.IO.Path]::GetFullPath($BundleDirectory)
+$metadataPath = Join-Path $bundleDirectory 'release-metadata.json'
+
+if (-not (Test-Path $bundleDirectory))
+{
+    throw "Bundle directory '$bundleDirectory' was not found."
+}
+
+if (-not (Test-Path $metadataPath))
+{
+    throw "Release metadata file '$metadataPath' was not found."
+}
+
+$metadata = Get-Content -Path $metadataPath -Raw | ConvertFrom-Json
+if ([string]::IsNullOrWhiteSpace($metadata.version))
+{
+    throw "Release metadata in '$metadataPath' did not contain a version."
+}
+
+$updatedAssets =
+    @($metadata.assets |
+        ForEach-Object {
+            $assetPath = Join-Path $bundleDirectory $_.name
+            if (-not (Test-Path $assetPath))
+            {
+                throw "Release asset '$assetPath' was not found."
+            }
+
+            [ordered]@{
+                name = $_.name
+                runtimeIdentifier = $_.runtimeIdentifier
+                platform = $_.platform
+                architecture = $_.architecture
+                fileType = $_.fileType
+                commandName = $_.commandName
+                sha256 = (Get-FileHash -Path $assetPath -Algorithm SHA256).Hash.ToLowerInvariant()
+            }
+        } |
+        Sort-Object name)
+
+$checksumsPath = Join-Path $bundleDirectory 'checksums.txt'
+$checksums = $updatedAssets | ForEach-Object { "$($_.sha256)  $($_.name)" }
+$checksums | Set-Content -Path $checksumsPath
+
+$updatedMetadata = [ordered]@{
+    version = $metadata.version
+    assets = $updatedAssets
+    windowsAssets = @($updatedAssets | Where-Object { $_.platform -eq 'win' })
+}
+
+$updatedMetadata | ConvertTo-Json -Depth 5 | Set-Content -Path $metadataPath


### PR DESCRIPTION
## Summary
- refactor `release.yml` into prepare/sign/publish jobs so Windows artifacts are signed only during release
- add helper scripts to expand Windows archives, repack signed zips, and regenerate release metadata/checksums
- document the release-only signing behavior in `README.md`

## Testing
- dotnet build kusto.slnx
- dotnet test kusto.slnx
- synthetic PowerShell validation of the expand/sign/repack/metadata regeneration flow