### PR TITLE
Make install-scripts workflow dispatch-only

### DIFF
--- a/.github/workflows/install-scripts.yml
+++ b/.github/workflows/install-scripts.yml
@@ -1,11 +1,6 @@
 name: Install Scripts
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - 'scripts/install/install-kusto-cli.ps1'
-      - '.github/workflows/install-scripts.yml'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary
- make `.github/workflows/install-scripts.yml` manual-only by removing the `push` trigger
- keep the workflow available via `workflow_dispatch` for intentional installer signing/publishing runs

## Validation
- Reviewed workflow diff to confirm only the trigger changed

Fixes the unintended auto-run behavior after #16.