### PR TITLE
Install .NET SDK in install-scripts workflow

### DIFF
--- a/.github/workflows/install-scripts.yml
+++ b/.github/workflows/install-scripts.yml
@@ -16,6 +16,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
+      - name: Setup .NET
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9
+        with:
+          dotnet-version: '10.0.x'
+
       - name: Stage install script
         shell: pwsh
         run: |


### PR DESCRIPTION
## Summary
- install the .NET SDK in the `install-scripts` workflow before invoking the Azure signing action
- keep the workflow otherwise unchanged and manual-only

## Validation
- reviewed workflow diff to confirm the .NET setup step is present before signing