### PR TITLE
Keep install-scripts release off latest

### DIFF
--- a/.github/workflows/install-scripts.yml
+++ b/.github/workflows/install-scripts.yml
@@ -98,12 +98,14 @@ jobs:
           if gh release view "$RELEASE_TAG" --repo "${{ github.repository }}" &>/dev/null; then
             gh release edit "$RELEASE_TAG" \
               --repo "${{ github.repository }}" \
+              --latest=false \
               --title "$RELEASE_TITLE" \
               --notes "$NOTES" \
               --target "${{ github.sha }}"
           else
             gh release create "$RELEASE_TAG" \
               --repo "${{ github.repository }}" \
+              --latest=false \
               --target "${{ github.sha }}" \
               --title "$RELEASE_TITLE" \
               --notes "$NOTES"


### PR DESCRIPTION
## Summary
- update the install-scripts workflow so the standing `install-scripts` release is explicitly not marked as the repository latest release
- apply the setting for both release creation and release updates

## Validation
- reviewed the workflow diff to confirm `--latest=false` is applied to both `gh release create` and `gh release edit`