### PR TITLE
Fix install script release enumeration

### DIFF
--- a/scripts/install/install-kusto-cli.ps1
+++ b/scripts/install/install-kusto-cli.ps1
@@ -119,7 +119,7 @@ function Invoke-GitHubApi
         $headers.Authorization = "Bearer $token"
     }
 
-    return Invoke-RestMethod -Method Get -Uri $Uri -Headers $headers
+    Invoke-RestMethod -Method Get -Uri $Uri -Headers $headers
 }
 
 function Invoke-GitHubAssetDownload
@@ -210,7 +210,7 @@ function Get-ReleaseForQuality
         $devRelease = Get-ReleaseByTag -Repo $Repo -Tag 'dev'
         if ($null -eq $devRelease)
         {
-            $releases = @(Invoke-GitHubApi -Uri "https://api.github.com/repos/$Repo/releases?per_page=100")
+            $releases = @(Invoke-GitHubApi -Uri "https://api.github.com/repos/$Repo/releases?per_page=100" | ForEach-Object { $_ })
             $devRelease = $releases | Where-Object { $_.name -eq 'Development Build' } | Select-Object -First 1
         }
 
@@ -228,7 +228,7 @@ function Get-ReleaseForQuality
         return $devRelease
     }
 
-    $allReleases = @(Invoke-GitHubApi -Uri "https://api.github.com/repos/$Repo/releases?per_page=100")
+    $allReleases = @(Invoke-GitHubApi -Uri "https://api.github.com/repos/$Repo/releases?per_page=100" | ForEach-Object { $_ })
     foreach ($release in $allReleases)
     {
         if ($release.draft)


### PR DESCRIPTION
## Summary
- fix release enumeration in `install-kusto-cli.ps1` so GitHub release list responses are expanded before filtering
- restore the default Stable install flow when a stable release like `v0.0.2` exists

## Validation
- pwsh ./scripts/Verify-PowerShellSyntax.ps1
- dotnet build kusto.slnx --nologo --tl:off
- dotnet test kusto.slnx --nologo --tl:off
- pwsh ./scripts/install/install-kusto-cli.ps1 -TargetPath $env:TEMP\kusto-install-smoke -UpdatePath:$false