### PR TITLE
Add query validation and AOT CI guardrails

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -1,9 +1,17 @@
 name: Build
-description: Setup .NET, restore, and build the solution
+description: Setup .NET, restore, build the solution, and optionally validate a NativeAOT publish
 
 inputs:
   version:
     description: Semantic version to inject into the build.
+    required: false
+    default: ''
+  validate-native-aot:
+    description: Whether to validate a NativeAOT publish on the current runner.
+    required: false
+    default: 'false'
+  aot-runtime-identifier:
+    description: Runtime identifier to use when validate-native-aot is enabled.
     required: false
     default: ''
 
@@ -27,3 +35,31 @@ runs:
         else
           dotnet build kusto.slnx --configuration Release --no-restore --nologo --tl:off -p:ContinuousIntegrationBuild=true
         fi
+
+    - name: Validate NativeAOT publish
+      if: inputs.validate-native-aot == 'true'
+      shell: pwsh
+      run: |
+        if ('${{ inputs.aot-runtime-identifier }}' -eq '') {
+          throw "The 'aot-runtime-identifier' input is required when validate-native-aot is enabled."
+        }
+
+        $arguments = @(
+          'publish',
+          './src/Kusto.Cli/Kusto.Cli.csproj',
+          '--configuration', 'Release',
+          '--runtime', '${{ inputs.aot-runtime-identifier }}',
+          '--self-contained', 'true',
+          '--nologo',
+          '--tl:off',
+          '-p:ContinuousIntegrationBuild=true'
+        )
+
+        if ('${{ inputs.version }}' -ne '') {
+          $arguments += "-p:Version=${{ inputs.version }}"
+        }
+
+        & dotnet @arguments
+        if ($LASTEXITCODE -ne 0) {
+          throw "dotnet publish failed for runtime '${{ inputs.aot-runtime-identifier }}'."
+        }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,8 @@ jobs:
         uses: ./.github/actions/build
         with:
           version: ${{ needs.version.outputs.version }}
+          validate-native-aot: 'true'
+          aot-runtime-identifier: linux-x64
 
       - name: Test
         run: dotnet test kusto.slnx --configuration Release --no-build --nologo --tl:off --logger "trx;LogFileName=test-results.trx" --logger "html;LogFileName=test-results.html" --results-directory ./test-results

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -30,6 +30,9 @@ jobs:
 
       - name: Build
         uses: ./.github/actions/build
+        with:
+          validate-native-aot: 'true'
+          aot-runtime-identifier: linux-x64
 
   test:
     needs: [validate-powershell-scripts]
@@ -87,33 +90,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
-      - name: Setup .NET
-        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9
+      - name: Build and validate NativeAOT publish
+        uses: ./.github/actions/build
         with:
-          dotnet-version: '10.0.x'
-
-      - name: Install linux-arm64 prerequisites
-        if: matrix.rid == 'linux-arm64'
-        shell: bash
-        run: |
-          set -euo pipefail
-          sudo dpkg --add-architecture arm64
-          sudo bash -c 'cat > /etc/apt/sources.list.d/arm64.list <<EOF
-          deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ jammy main restricted
-          deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ jammy-updates main restricted
-          deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ jammy-backports main restricted universe multiverse
-          EOF'
-          sudo sed -i -e 's/^deb /deb [arch=amd64] /g' /etc/apt/sources.list
-          sudo apt update
-          sudo apt install -y clang llvm binutils-aarch64-linux-gnu gcc-aarch64-linux-gnu zlib1g-dev:arm64
-
-      - name: Run dotnet publish (windows)
-        if: matrix.rid == 'win-x64' || matrix.rid == 'win-arm64'
-        shell: pwsh
-        run: dotnet publish .\src\Kusto.Cli\ -r '${{ matrix.rid }}'
-      
-      - name: Run dotnet publish (non-windows)
-        if: matrix.rid != 'win-x64' && matrix.rid != 'win-arm64'
-        shell: bash
-        run: dotnet publish ./src/Kusto.Cli/ -r '${{ matrix.rid }}'
+          validate-native-aot: 'true'
+          aot-runtime-identifier: ${{ matrix.rid }}
 

--- a/src/Kusto.Cli/CommandFactory.cs
+++ b/src/Kusto.Cli/CommandFactory.cs
@@ -539,6 +539,7 @@ public static class CommandFactory
                     Console.IsInputRedirected,
                     Console.In,
                     ct);
+                QueryValidator.Validate(query);
 
                 var result = await runtime.KustoService.ExecuteQueryAsync(
                     resolvedCluster.Url,

--- a/src/Kusto.Cli/Kusto.Cli.csproj
+++ b/src/Kusto.Cli/Kusto.Cli.csproj
@@ -22,6 +22,7 @@
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.18.0" />
     <PackageReference Include="Hex1b" Version="0.116.0" />
+    <PackageReference Include="Microsoft.Azure.Kusto.Language" Version="12.3.2" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.3" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.3" />
     <PackageReference Include="Spectre.Console" Version="0.54.0" />

--- a/src/Kusto.Cli/QueryValidator.cs
+++ b/src/Kusto.Cli/QueryValidator.cs
@@ -1,0 +1,66 @@
+using Kusto.Language;
+
+namespace Kusto.Cli;
+
+internal static class QueryValidator
+{
+    public static void Validate(string query)
+    {
+        if (string.IsNullOrWhiteSpace(query))
+        {
+            throw new UserFacingException("The query text cannot be empty.");
+        }
+
+        var parsedQuery = KustoCode.Parse(query);
+        var errors = parsedQuery.GetDiagnostics()
+            .Where(static diagnostic => diagnostic.Severity == DiagnosticSeverity.Error)
+            .ToArray();
+
+        if (errors.Length == 0)
+        {
+            return;
+        }
+
+        var primaryError = errors[0];
+        var additionalErrorsSuffix = errors.Length > 1
+            ? $" (and {errors.Length - 1} more error(s))"
+            : string.Empty;
+        var locationSuffix = primaryError.HasLocation
+            ? FormatLocation(query, primaryError.Start)
+            : string.Empty;
+
+        throw new UserFacingException($"The query is invalid{locationSuffix}: {primaryError.Message}{additionalErrorsSuffix}");
+    }
+
+    private static string FormatLocation(string query, int start)
+    {
+        var line = 1;
+        var column = 1;
+
+        for (var i = 0; i < start && i < query.Length; i++)
+        {
+            if (query[i] == '\r')
+            {
+                if (i + 1 < query.Length && query[i + 1] == '\n')
+                {
+                    i++;
+                }
+
+                line++;
+                column = 1;
+                continue;
+            }
+
+            if (query[i] == '\n')
+            {
+                line++;
+                column = 1;
+                continue;
+            }
+
+            column++;
+        }
+
+        return $" at line {line}, column {column}";
+    }
+}

--- a/tests/Kusto.Cli.Tests/QueryCommandTests.cs
+++ b/tests/Kusto.Cli.Tests/QueryCommandTests.cs
@@ -2,6 +2,7 @@ using System.CommandLine;
 
 namespace Kusto.Cli.Tests;
 
+[Collection("Console")]
 public sealed class QueryCommandTests
 {
     [Fact]
@@ -14,4 +15,31 @@ public sealed class QueryCommandTests
 
         Assert.Equal(1, exitCode);
     }
+
+    [Fact]
+    public async Task Query_WithInvalidSyntax_ReturnsValidationError()
+    {
+        var rootCommand = CommandFactory.CreateRootCommand();
+        var originalError = Console.Error;
+        using var errorWriter = new StringWriter();
+        Console.SetError(errorWriter);
+
+        try
+        {
+            var exitCode = await rootCommand.Parse(
+                    ["query", "StormEvents | where", "--cluster", "https://help.kusto.windows.net", "--database", "Samples"],
+                    new ParserConfiguration())
+                .InvokeAsync();
+
+            Assert.Equal(1, exitCode);
+            Assert.Contains("The query is invalid", errorWriter.ToString(), StringComparison.Ordinal);
+        }
+        finally
+        {
+            Console.SetError(originalError);
+        }
+    }
 }
+
+[CollectionDefinition("Console", DisableParallelization = true)]
+public sealed class ConsoleCollectionDefinition;

--- a/tests/Kusto.Cli.Tests/QueryValidatorTests.cs
+++ b/tests/Kusto.Cli.Tests/QueryValidatorTests.cs
@@ -1,0 +1,37 @@
+namespace Kusto.Cli.Tests;
+
+public sealed class QueryValidatorTests
+{
+    [Theory]
+    [InlineData("print 1")]
+    [InlineData("StormEvents | take 5")]
+    public void Validate_ValidQuery_DoesNotThrow(string query)
+    {
+        QueryValidator.Validate(query);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    public void Validate_EmptyQuery_ThrowsUserFacingException(string query)
+    {
+        var exception = Assert.Throws<UserFacingException>(() => QueryValidator.Validate(query));
+        Assert.Contains("cannot be empty", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData("StormEvents | where")]
+    [InlineData("print(")]
+    public void Validate_InvalidQuery_ThrowsUserFacingException(string query)
+    {
+        var exception = Assert.Throws<UserFacingException>(() => QueryValidator.Validate(query));
+        Assert.Contains("The query is invalid", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Validate_MultilineInvalidQuery_IncludesLineAndColumn()
+    {
+        var exception = Assert.Throws<UserFacingException>(() => QueryValidator.Validate("print 1\r\n| where"));
+        Assert.Contains("at line 2, column 8", exception.Message, StringComparison.Ordinal);
+    }
+}


### PR DESCRIPTION
## Summary
- validate `kusto query` text locally with `Microsoft.Azure.Kusto.Language` before sending requests
- add validator coverage, including a multiline CRLF line/column assertion and a command-path invalid query test
- refactor the shared build action to optionally validate a NativeAOT publish, enable that in CI and PR builds, and reuse it in the PR AOT matrix job

## Validation
- `dotnet test kusto.slnx`
- `dotnet publish --os win .\src\Kusto.Cli\Kusto.Cli.csproj`
- `python -c "import yaml, pathlib; [yaml.safe_load(pathlib.Path(p).read_text()) for p in [''.github/actions/build/action.yml'', ''.github/workflows/ci.yml'', ''.github/workflows/pr.yml'']]"`

Closes #21