### PR TITLE
Optimize Native AOT publish for size

### DIFF
--- a/src/Kusto.Cli/Kusto.Cli.csproj
+++ b/src/Kusto.Cli/Kusto.Cli.csproj
@@ -8,6 +8,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PublishAot>true</PublishAot>
+    <OptimizationPreference>Size</OptimizationPreference>
     <InvariantGlobalization>true</InvariantGlobalization>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <Company>Damian Edwards</Company>


### PR DESCRIPTION
## Summary
- add OptimizationPreference=Size to the CLI project
- keep the existing AOT and invariant globalization settings unchanged
- adopt the lowest-risk publish-size optimization found in local testing

## Validation
- dotnet build .\\kusto.slnx
- dotnet test .\\kusto.slnx --no-build
- dotnet publish .\\src\\Kusto.Cli\\Kusto.Cli.csproj -c Release -r win-x64 --self-contained true

## Notes
Local win-x64 self-contained publishing reduced kusto.exe from about 21.04 MiB to 17.04 MiB after this change.