### PR TITLE
Update actions/setup-dotnet to v5.2.0 SHA

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -19,7 +19,7 @@ runs:
   using: composite
   steps:
     - name: Setup .NET
-      uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9
+      uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7
       with:
         dotnet-version: '10.0.x'
 


### PR DESCRIPTION
## Summary
- update the shared `.github/actions/build/action.yml` composite action to pin `actions/setup-dotnet` to the `v5.2.0` SHA `c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7`
- bring the last stale `setup-dotnet` reference in the repo in line with the already-updated workflow files
- document that this addresses the `setup-dotnet` portion of issue #30, while the remaining Node 20 warning is still blocked on another action upgrade

## Validation
- `dotnet build kusto.slnx --nologo`
- `dotnet test kusto.slnx --nologo`

Part of #30.