### PR TITLE
Update action pins for Node 24 support

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -119,7 +119,7 @@ jobs:
           retention-days: 30
 
       - name: Publish test results
-        uses: dorny/test-reporter@3d76b34a4535afbd0600d347b09a6ee5deb3ed7f
+        uses: dorny/test-reporter@2dcf091ad558da2cabf16f6b423e02cd078c937a
         if: always()
         with:
           name: Test Results

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,7 @@ jobs:
           retention-days: 30
 
       - name: Publish test results
-        uses: dorny/test-reporter@3d76b34a4535afbd0600d347b09a6ee5deb3ed7f
+        uses: dorny/test-reporter@2dcf091ad558da2cabf16f6b423e02cd078c937a
         if: always()
         with:
           name: Test Results

--- a/.github/workflows/install-scripts.yml
+++ b/.github/workflows/install-scripts.yml
@@ -35,7 +35,7 @@ jobs:
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
       - name: Sign install script
-        uses: azure/artifact-signing-action@87c2e83e6868da99d3380aa309851b32ed9a8346
+        uses: azure/artifact-signing-action@b443cf8ea4124818d2ea9f043cba29fc3ec47b16
         with:
           endpoint: ${{ secrets.AZURE_SIGNING_ENDPOINT }}
           signing-account-name: ${{ secrets.AZURE_SIGNING_ACCOUNT }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -180,7 +180,7 @@ jobs:
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
       - name: Sign Windows executables
-        uses: azure/artifact-signing-action@87c2e83e6868da99d3380aa309851b32ed9a8346
+        uses: azure/artifact-signing-action@b443cf8ea4124818d2ea9f043cba29fc3ec47b16
         with:
           endpoint: ${{ secrets.AZURE_SIGNING_ENDPOINT }}
           signing-account-name: ${{ secrets.AZURE_SIGNING_ACCOUNT }}


### PR DESCRIPTION
Fixes #30.

This updates the remaining pinned GitHub Actions that were still producing Node 20 deprecation warnings:
- dorny/test-reporter -> Node 24-compatible v3.0.0 commit
- Azure/artifact-signing-action -> upstream fix commit for internal actions/cache v5

Validation:
- dotnet build kusto.slnx --nologo
- dotnet test kusto.slnx --nologo