### PR TITLE
Implement table command improvements

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -25,13 +25,15 @@ There is no separate lint command configured in this repository.
 
 ### 2) Runtime composition and execution flow
 - `src/Kusto.Cli/CliRunner.cs` is the command execution wrapper: it parses common options (`--format`, `--log-level`), constructs runtime dependencies, formats output, and centralizes error handling.
-- `CliRunner.CreateRuntime(...)` wires `FileConfigStore`, `KustoConnectionResolver`, `AzureTokenProvider`, `KustoHttpService`, and `OutputFormatter` into a `CliRuntime`.
-- `src/Kusto.Cli/Contracts.cs` defines the core interfaces (`IConfigStore`, `IKustoService`, `IKustoConnectionResolver`, `IOutputFormatter`) and `CliRuntime` container.
+- `CliRunner.CreateRuntime(...)` wires `FileConfigStore`, `KustoConnectionResolver`, `AzureTokenProvider`, `KustoHttpService`, `OfflineTableDataStore`, `TableSchemaProvider`, `TableOfflineDataManager`, the confirmation prompt, and `OutputFormatter` into a `CliRuntime`.
+- `src/Kusto.Cli/Contracts.cs` defines the core interfaces (`IConfigStore`, `IKustoService`, `IKustoConnectionResolver`, `ITableSchemaProvider`, `ITableOfflineDataManager`, `IConfirmationPrompt`, `IOutputFormatter`) and the `CliRuntime` container.
 
 ### 3) Data/config and connection resolution
 - `src/Kusto.Cli/FileConfigStore.cs` persists config to `%USERPROFILE%\.kusto\config.json` (or `KUSTO_CONFIG_PATH` override).
 - `src/Kusto.Cli/ClusterUtilities.cs` normalizes cluster URLs and config values; defaults and lookups rely on normalized URLs.
 - `src/Kusto.Cli/KustoConnectionResolver.cs` resolves effective cluster/database from explicit options or configured defaults.
+- `src/Kusto.Cli/OfflineTableDataStore.cs` persists offline table data per normalized cluster/database in the schema-cache directory; each entry can hold cached schema JSON plus per-table notes.
+- `src/Kusto.Cli/TableSchemaProvider.cs` reads/refreshes cached schema data for `table show`, while `src/Kusto.Cli/TableOfflineDataManager.cs` owns notes and offline-data import/export/purge/clear flows.
 
 ### 4) Kusto transport layer
 - `src/Kusto.Cli/KustoHttpService.cs` calls Kusto REST endpoints:
@@ -81,7 +83,16 @@ There is no separate lint command configured in this repository.
    - Command handlers should return `CliOutput` (`Message`, `Properties`, `Table`) and rely on `OutputFormatter`.
    - Prefer returning structured data and let formatter handle rendering differences across output modes.
 
-6. **Chart compatibility rules are centralized**
+6. **Offline table data is keyed by normalized cluster URL + database**
+   - Reuse the schema-cache directory and normalize cluster URLs before persisting or looking up offline table data.
+   - `table show` should render table metadata in `Properties`, column details in `Table`, and surface stored notes in the text output.
+   - Table notes are stored per table with sequential IDs derived from list order; do not invent separate GUID-style note identifiers.
+
+7. **Destructive offline-data actions must confirm unless forced**
+   - `table notes --clear`, `table --purge-offline-data`, and `table --clear-offline-data` should prompt unless `--force` is supplied.
+   - Keep destructive-operation prompts explicit and route behavior through the confirmation prompt abstraction rather than ad-hoc console reads in command handlers.
+
+8. **Chart compatibility rules are centralized**
    - Always route render-kind and layout decisions through `KustoChartCompatibilityAnalyzer`; do not duplicate chart compatibility logic in command handlers or formatters.
    - Current render-kind mapping is:
      - `columnchart` => `QueryChartKind.Column`
@@ -90,13 +101,13 @@ There is no separate lint command configured in this repository.
      - `piechart` => `QueryChartKind.Pie`
    - Any other Kusto render kind should surface an explicit "not supported" reason rather than silently falling back.
 
-7. **Human vs markdown chart support differs intentionally**
+9. **Human vs markdown chart support differs intentionally**
    - Terminal (`human` + `--chart`) currently supports `columnchart`, `barchart`, `linechart`/`timechart`, and `piechart`.
    - Markdown (`markdown`/`md` + `--chart`) supports those same chart kinds.
    - `piechart` terminal output should render via Hex1b's donut/pie support and include a legend with values/percentages when feasible.
    - Mermaid cartesian output currently requires `Simple` layout and exactly one series; if the chart can't be represented faithfully, preserve the table and emit the markdown reason instead of approximating.
 
-8. **Layout support is chart-kind specific**
+10. **Layout support is chart-kind specific**
    - For line charts, supported human layouts are `default`/`unstacked`, `stacked`, and `stacked100`.
    - For column/bar charts, supported human layouts are `default`/`unstacked`, `grouped`, `stacked`, and `stacked100`.
    - Invalid or unsupported layouts must fail compatibility analysis with a clear reason before rendering.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Grab the relevant executable asset from the latest [release](https://github.com/
 
 - Manage known clusters (`cluster` command group)
 - Manage databases and defaults (`database` command group)
-- Browse tables and schemas (`table` command group)
+- Browse tables, schema details, and offline table data (`table` command group)
 - Run KQL from inline text, files, or stdin (`query`)
 - Show copy/paste-ready examples and aliases (`examples`)
 - Include Azure Data Explorer Web Explorer deeplinks in query results
@@ -27,7 +27,7 @@ Grab the relevant executable asset from the latest [release](https://github.com/
 - Show optional query execution statistics with `--show-stats`
 - Basic public, US Government, and China cloud support for token audience selection and Web Explorer links
 - Multiple output formats (`human`, `json`, `markdown`/`md`)
-- Optional table schema caching with TTL-based revalidation for repeated `table show` calls
+- Optional offline table data with TTL-based schema revalidation, per-table notes, and import/export support
 - Configurable log verbosity with structured console/file logging
 - GitHub Actions workflows for PR validation, versioned native release assets, and release promotion
 
@@ -199,9 +199,11 @@ Line chart example:
 
 If a query returns visualization metadata but `--chart` is omitted, the CLI will hint when the result is compatible with terminal chart rendering. If a render kind or layout can't be mapped faithfully to Hex1b or Mermaid, the CLI will keep the table output and show an explanatory message instead.
 
-## Schema cache
+## Offline table data
 
-`table show` uses an on-disk schema cache by default for repeated schema discovery. For configuration, cache locations, disable/override behavior, and usage examples, see [docs/schema-cache.md](docs/schema-cache.md).
+`table show` uses on-disk offline table data by default for repeated schema discovery. The CLI caches database schema snapshots, revalidates expired entries with `.show database ['<db>'] schema if_later_than "<version>" as json`, includes table and column docstrings in `table show`, and lets you attach per-table notes that are echoed back in `table show`.
+
+For configuration, cache locations, disable/override behavior, and offline-data management examples, see [docs/schema-cache.md](docs/schema-cache.md).
 
 ## Global options
 
@@ -227,8 +229,10 @@ These options are available on all commands:
 | `database list` | List databases in a cluster. | none | `--cluster`, `--filter`, `--take`, global options |
 | `database show <database>` | Show details for one database. | `database` | `--cluster`, global options |
 | `database set-default <database>` | Set default database for a cluster. | `database` | `--cluster`, global options |
+| `table [<table>]` | Manage offline table data at the root command level. | optional `table` | `--export-offline-data`, `--import-offline-data`, `--purge-offline-data`, `--clear-offline-data`, `--cluster`, `--database`, `--force`, global options |
 | `table list` | List tables in a database. | none | `--cluster`, `--database`, `--filter`, `--take`, global options |
-| `table show <table>` | Show schema/details for one table. | `table` | `--cluster`, `--database`, global options |
+| `table show <table>` | Show table details, column schema, docstrings, and stored notes. | `table` | `--cluster`, `--database`, `--refresh-offline-data`, global options |
+| `table notes [<table>]` | List, add, delete, or clear table notes. | optional `table` | `--cluster`, `--database`, `--add`, `--id`, `--delete`, `--clear`, `--force`, global options |
 | `query [<query>]` | Run KQL from inline text, file, or stdin. | optional `query` | `--file`, `--cluster`, `--database`, `--chart`, `--show-stats`, global options |
 
 ## Command-specific option details
@@ -239,6 +243,16 @@ These options are available on all commands:
 | `--database <database>` | `table *`, `query` | Database to use. Alias: `--db`. If omitted, default DB for selected cluster is used. |
 | `--filter <value>` | `database list`, `table list` | Name filter. Supports contains/startswith/endswith semantics using anchors (see below). |
 | `--take <int>` | `database list`, `table list` | Limits number of rows returned. Alias: `--limit`. Must be a positive integer. |
+| `--refresh-offline-data` | `table show` | Force a live schema refresh and update the local offline table data. Alias: `-r`. |
+| `--add <note>` | `table notes <table>` | Add a note for the specified table. Alias: `-a`. |
+| `--id <int>` | `table notes <table>` | Show a specific note by its sequential ID. |
+| `--delete <int>` | `table notes <table>` | Delete a specific note by its sequential ID. Alias: `-d`. |
+| `--clear` | `table notes`, `table [<table>]` | Clear table notes or clear offline table data, depending on the command context. Alias: `-c`. |
+| `--export-offline-data <path>` | `table` | Export all offline table data to JSON. |
+| `--import-offline-data <path>` | `table` | Import offline table data from JSON. |
+| `--purge-offline-data` | `table` | Remove offline data for tables that no longer exist. Alias: `-p`. |
+| `--clear-offline-data` | `table [<table>]` | Clear offline data for one table or for all tables. Alias: `-c`. |
+| `--force` | destructive `table` / `table notes` actions | Skip the confirmation prompt when clearing or purging offline data. Alias: `-f`. |
 | `--use` | `cluster add` | Also set the added cluster as the active/default cluster. |
 | `--file <path>` | `query` | Read query text from file. Alias: `-f`. Cannot be combined with inline query argument. |
 | `--chart` | `query` | Render compatible query results as a chart for `human` or `markdown` output. Not supported with `json`. |
@@ -261,7 +275,13 @@ Canonical command names are used in the examples above. These aliases are still 
 | `set-default` | `use` |
 | `--database` | `--db` |
 | `--take` | `--limit` |
+| `--refresh-offline-data` | `-r` |
+| `--add` | `-a` |
+| `--delete` | `-d` |
+| `--clear`, `--clear-offline-data` | `-c` |
+| `--purge-offline-data` | `-p` |
 | `--file` | `-f` |
+| `--force` | `-f` |
 
 ### `--filter` semantics
 
@@ -317,6 +337,23 @@ kusto table list --cluster help --database Samples --filter "^Storm" --take 10
 
 # Show a specific table schema/details
 kusto table show StormEvents --cluster help --database Samples
+
+# Force a live refresh of the cached table details
+kusto table show StormEvents --cluster help --database Samples --refresh-offline-data
+
+# Add and inspect table notes
+kusto table notes StormEvents --cluster help --database Samples --add "Use this table for weather samples."
+kusto table notes StormEvents --cluster help --database Samples
+
+# Delete a specific note or clear notes
+kusto table notes StormEvents --cluster help --database Samples --delete 1
+kusto table notes --clear --force
+
+# Export/import or clear offline data
+kusto table --export-offline-data .\offline-table-data.json
+kusto table --import-offline-data .\offline-table-data.json
+kusto table StormEvents --cluster help --database Samples --clear-offline-data --force
+kusto table --purge-offline-data --force
 ```
 
 ### Query command

--- a/docs/schema-cache.md
+++ b/docs/schema-cache.md
@@ -1,10 +1,17 @@
-# Schema cache
+# Offline table data
 
-`table show` uses an on-disk schema cache by default. The CLI caches database schema snapshots and revalidates expired entries with `.show database ['<db>'] schema if_later_than "<version>" as json` before downloading a full replacement.
+`table show` uses on-disk offline table data by default. The CLI caches database schema snapshots, revalidates expired entries with `.show database ['<db>'] schema if_later_than "<version>" as json`, and stores per-table notes alongside that cached schema data.
+
+That means the offline data currently covers:
+
+- cached table schema details used by `table show`
+- table-level docstrings
+- column-level docstrings when Kusto returns them in the schema payload
+- per-table notes created with `table notes`
 
 ## Defaults
 
-- Default: enabled
+- Default automatic schema caching: enabled
 - Default cache paths:
   - Windows: `%LOCALAPPDATA%\kusto\schema-cache`
   - Linux: `$XDG_CACHE_HOME\kusto\schema-cache` or `~/.cache/kusto/schema-cache`
@@ -16,7 +23,9 @@
 - `KUSTO_SCHEMA_CACHE_PATH`
 - `KUSTO_SCHEMA_CACHE_TTL_SECONDS`
 
-Set `KUSTO_SCHEMA_CACHE_ENABLED=false` or `"enabled": false` in `config.json` if you want to turn the cache off.
+Set `KUSTO_SCHEMA_CACHE_ENABLED=false` or `"enabled": false` in `config.json` if you want to turn off automatic schema reuse for `table show`.
+
+Notes and manual offline-data operations still use the same on-disk location, and `table show --refresh-offline-data` can repopulate the cache on demand.
 
 ## Example: PowerShell
 
@@ -24,12 +33,22 @@ Set `KUSTO_SCHEMA_CACHE_ENABLED=false` or `"enabled": false` in `config.json` if
 # Override the default TTL for this shell
 $env:KUSTO_SCHEMA_CACHE_TTL_SECONDS = "3600"
 
-# First call populates the cache
+# First call populates the offline data
 kusto table show StormEvents --cluster help --database Samples
 
-# Later calls reuse the cached database schema until TTL expiry,
-# then revalidate with if_later_than before downloading a replacement
-kusto table show StormEvents --cluster help --database Samples
+# Add a note that will be echoed back in later `table show` output
+kusto table notes StormEvents --cluster help --database Samples --add "Use this for weather samples."
+
+# Force a live refresh of the schema/docstrings and overwrite the cached copy
+kusto table show StormEvents --cluster help --database Samples --refresh-offline-data
+
+# Export/import offline data as JSON
+kusto table --export-offline-data .\offline-table-data.json
+kusto table --import-offline-data .\offline-table-data.json
+
+# Purge or clear offline data
+kusto table --purge-offline-data --force
+kusto table StormEvents --cluster help --database Samples --clear-offline-data --force
 ```
 
 ## Example: config.json
@@ -58,3 +77,10 @@ kusto table show StormEvents --cluster help --database Samples
   }
 }
 ```
+
+## Notes on destructive operations
+
+- `table notes --clear` prompts before clearing all notes unless `--force` is supplied.
+- `table <table> --clear-offline-data` prompts before removing cached schema data and notes for that table unless `--force` is supplied.
+- `table --clear-offline-data` prompts before removing all offline table data unless `--force` is supplied.
+- `table --purge-offline-data` prompts before verifying cached tables against live clusters/databases unless `--force` is supplied.

--- a/src/Kusto.Cli/CliRunner.cs
+++ b/src/Kusto.Cli/CliRunner.cs
@@ -82,10 +82,18 @@ public static class CliRunner
         var tokenProvider = new AzureTokenProvider();
         var httpClient = new HttpClient();
         var kustoService = new KustoHttpService(httpClient, tokenProvider, loggerFactory.CreateLogger<KustoHttpService>());
+        var settingsResolver = new SchemaCacheSettingsResolver();
+        var offlineTableDataStore = new OfflineTableDataStore(settingsResolver, loggerFactory.CreateLogger<OfflineTableDataStore>());
         var tableSchemaProvider = new TableSchemaProvider(
             kustoService,
-            new SchemaCacheSettingsResolver(),
+            offlineTableDataStore,
+            settingsResolver,
             loggerFactory.CreateLogger<TableSchemaProvider>());
+        var tableOfflineDataManager = new TableOfflineDataManager(
+            kustoService,
+            offlineTableDataStore,
+            loggerFactory.CreateLogger<TableOfflineDataManager>());
+        var confirmationPrompt = new ConsoleConfirmationPrompt(Console.In, stderrWriter ?? Console.Error);
         var formatter = new OutputFormatter();
 
         return new CliRuntime(
@@ -96,6 +104,8 @@ public static class CliRunner
             connectionResolver,
             kustoService,
             tableSchemaProvider,
+            tableOfflineDataManager,
+            confirmationPrompt,
             formatter);
     }
 }

--- a/src/Kusto.Cli/CommandFactory.cs
+++ b/src/Kusto.Cli/CommandFactory.cs
@@ -385,27 +385,196 @@ public static class CommandFactory
 
     private static Command BuildTableCommand(Option<string> formatOption, Option<string?> logLevelOption)
     {
-        var clusterOption = CreateClusterOption();
+        var rootTableArgument = new Argument<string?>("table")
+        {
+            Description = "Table name.",
+            Arity = ArgumentArity.ZeroOrOne
+        };
+        var rootClusterOption = CreateClusterOption();
+        var rootDatabaseOption = CreateDatabaseOption();
+        var exportOfflineDataOption = CreateOfflineDataFileOption("--export-offline-data", "Export all offline table data to a JSON file.");
+        var importOfflineDataOption = CreateOfflineDataFileOption("--import-offline-data", "Import offline table data from a JSON file.");
+        var purgeOfflineDataOption = new Option<bool>("--purge-offline-data")
+        {
+            Description = "Purge offline data for tables that no longer exist. Alias: -p."
+        };
+        purgeOfflineDataOption.Aliases.Add("-p");
+        var clearOfflineDataOption = new Option<bool>("--clear-offline-data")
+        {
+            Description = "Clear offline data for one table or all tables. Alias: -c."
+        };
+        clearOfflineDataOption.Aliases.Add("-c");
+        var rootForceOption = CreateForceOption("Skip the confirmation prompt for destructive offline-data operations.");
 
-        var databaseOption = CreateDatabaseOption();
+        var listClusterOption = CreateClusterOption();
+        var listDatabaseOption = CreateDatabaseOption();
         var filterOption = CreateFilterOption("table");
         var takeOption = CreateTakeOption("tables");
 
+        var showTableArgument = new Argument<string>("table")
+        {
+            Description = "Table name."
+        };
+        var showClusterOption = CreateClusterOption();
+        var showDatabaseOption = CreateDatabaseOption();
+        var refreshOfflineDataOption = new Option<bool>("--refresh-offline-data")
+        {
+            Description = "Fetch the latest table schema and update local offline data. Alias: -r."
+        };
+        refreshOfflineDataOption.Aliases.Add("-r");
+
+        var notesTableArgument = new Argument<string?>("table")
+        {
+            Description = "Table name.",
+            Arity = ArgumentArity.ZeroOrOne
+        };
+        var notesClusterOption = CreateClusterOption();
+        var notesDatabaseOption = CreateDatabaseOption();
+        var addNoteOption = new Option<string?>("--add")
+        {
+            Description = "Add a note for the specified table. Alias: -a."
+        };
+        addNoteOption.Aliases.Add("-a");
+        var noteIdOption = new Option<int?>("--id")
+        {
+            Description = "Show a specific note by its sequential ID."
+        };
+        var deleteNoteOption = new Option<int?>("--delete")
+        {
+            Description = "Delete a note by its sequential ID. Alias: -d."
+        };
+        deleteNoteOption.Aliases.Add("-d");
+        var clearNotesOption = new Option<bool>("--clear")
+        {
+            Description = "Clear notes for one table or all tables. Alias: -c."
+        };
+        clearNotesOption.Aliases.Add("-c");
+        var notesForceOption = CreateForceOption("Skip the confirmation prompt when clearing notes.");
+
         var tableCommand = new Command("table", "Browse tables and inspect schema.");
         tableCommand.Aliases.Add("tables");
+        tableCommand.Add(rootTableArgument);
+        tableCommand.Add(rootClusterOption);
+        tableCommand.Add(rootDatabaseOption);
+        tableCommand.Add(exportOfflineDataOption);
+        tableCommand.Add(importOfflineDataOption);
+        tableCommand.Add(purgeOfflineDataOption);
+        tableCommand.Add(clearOfflineDataOption);
+        tableCommand.Add(rootForceOption);
+        tableCommand.SetAction((parseResult, cancellationToken) =>
+        {
+            var tableName = parseResult.GetValue(rootTableArgument);
+            var clusterReference = parseResult.GetValue(rootClusterOption);
+            var databaseName = parseResult.GetValue(rootDatabaseOption);
+            var exportFile = parseResult.GetValue(exportOfflineDataOption);
+            var importFile = parseResult.GetValue(importOfflineDataOption);
+            var purgeOfflineData = parseResult.GetValue(purgeOfflineDataOption);
+            var clearOfflineData = parseResult.GetValue(clearOfflineDataOption);
+            var force = parseResult.GetValue(rootForceOption);
+            var format = parseResult.GetRequiredValue(formatOption);
+            var logLevel = parseResult.GetValue(logLevelOption);
+
+            return CliRunner.RunAsync(format, logLevel, async (runtime, ct) =>
+            {
+                var selectedActionCount = CountSpecified(
+                    exportFile is not null,
+                    importFile is not null,
+                    purgeOfflineData,
+                    clearOfflineData);
+
+                if (selectedActionCount == 0)
+                {
+                    if (!string.IsNullOrWhiteSpace(tableName))
+                    {
+                        throw new UserFacingException($"Use 'kusto table show {tableName}' to inspect a table or add --clear-offline-data to remove cached data.");
+                    }
+
+                    throw new UserFacingException("Specify a table subcommand or an offline-data option.");
+                }
+
+                if (selectedActionCount > 1)
+                {
+                    throw new UserFacingException("Specify only one offline-data action at a time.");
+                }
+
+                if (force && !purgeOfflineData && !clearOfflineData)
+                {
+                    throw new UserFacingException("--force can only be used with --purge-offline-data or --clear-offline-data.");
+                }
+
+                var config = await runtime.ConfigStore.LoadAsync(ct);
+
+                if (exportFile is not null)
+                {
+                    EnsureNoScopedTableOptions(tableName, clusterReference, databaseName, "--export-offline-data");
+                    return await runtime.TableOfflineDataManager.ExportOfflineDataAsync(config, exportFile.FullName, ct);
+                }
+
+                if (importFile is not null)
+                {
+                    EnsureNoScopedTableOptions(tableName, clusterReference, databaseName, "--import-offline-data");
+                    return await runtime.TableOfflineDataManager.ImportOfflineDataAsync(config, importFile.FullName, ct);
+                }
+
+                if (purgeOfflineData)
+                {
+                    EnsureNoScopedTableOptions(tableName, clusterReference, databaseName, "--purge-offline-data");
+                    if (!force && !await runtime.ConfirmationPrompt.ConfirmAsync("Purge offline data for tables that no longer exist?", ct))
+                    {
+                        return new CliOutput { Message = "Operation cancelled." };
+                    }
+
+                    return await runtime.TableOfflineDataManager.PurgeOfflineDataAsync(config, ct);
+                }
+
+                if (!clearOfflineData)
+                {
+                    throw new UserFacingException("Specify an offline-data action to run.");
+                }
+
+                if (string.IsNullOrWhiteSpace(tableName))
+                {
+                    if (!string.IsNullOrWhiteSpace(clusterReference) || !string.IsNullOrWhiteSpace(databaseName))
+                    {
+                        throw new UserFacingException("--cluster and --database can only be used with --clear-offline-data when a table name is provided.");
+                    }
+
+                    if (!force && !await runtime.ConfirmationPrompt.ConfirmAsync("Clear all offline table data?", ct))
+                    {
+                        return new CliOutput { Message = "Operation cancelled." };
+                    }
+
+                    return await runtime.TableOfflineDataManager.ClearOfflineDataAsync(config, null, null, null, ct);
+                }
+
+                var resolvedCluster = runtime.ConnectionResolver.ResolveCluster(config, clusterReference);
+                var resolvedDatabase = runtime.ConnectionResolver.ResolveDatabase(config, resolvedCluster.Url, databaseName);
+                if (!force && !await runtime.ConfirmationPrompt.ConfirmAsync($"Clear offline data for table '{tableName}'?", ct))
+                {
+                    return new CliOutput { Message = "Operation cancelled." };
+                }
+
+                return await runtime.TableOfflineDataManager.ClearOfflineDataAsync(
+                    config,
+                    resolvedCluster.Url,
+                    resolvedDatabase,
+                    tableName,
+                    ct);
+            }, cancellationToken);
+        });
 
         var listCommand = new Command("list", "List tables in a database. Use --filter or --limit to narrow results.")
         {
-            clusterOption,
-            databaseOption,
+            listClusterOption,
+            listDatabaseOption,
             filterOption,
             takeOption
         };
         listCommand.Aliases.Add("ls");
         listCommand.SetAction((parseResult, cancellationToken) =>
         {
-            var clusterReference = parseResult.GetValue(clusterOption);
-            var databaseName = parseResult.GetValue(databaseOption);
+            var clusterReference = parseResult.GetValue(listClusterOption);
+            var databaseName = parseResult.GetValue(listDatabaseOption);
             var filterValue = parseResult.GetValue(filterOption);
             var takeValue = parseResult.GetValue(takeOption);
             var format = parseResult.GetRequiredValue(formatOption);
@@ -433,24 +602,21 @@ public static class CommandFactory
             }, cancellationToken);
         });
 
-        var tableArgument = new Argument<string>("table")
-        {
-            Description = "Table name."
-        };
-
         var showCommand = new Command("show", "Show table schema and column details.")
         {
-            tableArgument,
-            clusterOption,
-            databaseOption
+            showTableArgument,
+            showClusterOption,
+            showDatabaseOption,
+            refreshOfflineDataOption
         };
         showCommand.Aliases.Add("get");
         showCommand.Aliases.Add("schema");
         showCommand.SetAction((parseResult, cancellationToken) =>
         {
-            var tableName = parseResult.GetRequiredValue(tableArgument);
-            var clusterReference = parseResult.GetValue(clusterOption);
-            var databaseName = parseResult.GetValue(databaseOption);
+            var tableName = parseResult.GetRequiredValue(showTableArgument);
+            var clusterReference = parseResult.GetValue(showClusterOption);
+            var databaseName = parseResult.GetValue(showDatabaseOption);
+            var refreshOfflineData = parseResult.GetValue(refreshOfflineDataOption);
             var format = parseResult.GetRequiredValue(formatOption);
             var logLevel = parseResult.GetValue(logLevelOption);
 
@@ -459,21 +625,164 @@ public static class CommandFactory
                 var config = await runtime.ConfigStore.LoadAsync(ct);
                 var resolvedCluster = runtime.ConnectionResolver.ResolveCluster(config, clusterReference);
                 var resolvedDatabase = runtime.ConnectionResolver.ResolveDatabase(config, resolvedCluster.Url, databaseName);
+                var details = await runtime.TableSchemaProvider.GetTableSchemaDetailsAsync(
+                    config,
+                    resolvedCluster.Url,
+                    resolvedDatabase,
+                    tableName,
+                    refreshOfflineData,
+                    ct);
 
                 return new CliOutput
                 {
-                    Properties = await runtime.TableSchemaProvider.GetTablePropertiesAsync(
+                    Message = details.NotesMessage,
+                    Properties = details.Properties,
+                    Table = details.Columns
+                };
+            }, cancellationToken);
+        });
+
+        var notesCommand = new Command("notes", "Manage extra notes associated with a table.")
+        {
+            notesTableArgument,
+            notesClusterOption,
+            notesDatabaseOption,
+            addNoteOption,
+            noteIdOption,
+            deleteNoteOption,
+            clearNotesOption,
+            notesForceOption
+        };
+        notesCommand.SetAction((parseResult, cancellationToken) =>
+        {
+            var tableName = parseResult.GetValue(notesTableArgument);
+            var clusterReference = parseResult.GetValue(notesClusterOption);
+            var databaseName = parseResult.GetValue(notesDatabaseOption);
+            var addNote = parseResult.GetValue(addNoteOption);
+            var noteId = parseResult.GetValue(noteIdOption);
+            var deleteNote = parseResult.GetValue(deleteNoteOption);
+            var clearNotes = parseResult.GetValue(clearNotesOption);
+            var force = parseResult.GetValue(notesForceOption);
+            var format = parseResult.GetRequiredValue(formatOption);
+            var logLevel = parseResult.GetValue(logLevelOption);
+
+            return CliRunner.RunAsync(format, logLevel, async (runtime, ct) =>
+            {
+                var selectedActionCount = CountSpecified(
+                    addNote is not null,
+                    noteId is not null,
+                    deleteNote is not null,
+                    clearNotes);
+
+                if (selectedActionCount > 1)
+                {
+                    throw new UserFacingException("Specify only one notes action at a time.");
+                }
+
+                if (force && !clearNotes)
+                {
+                    throw new UserFacingException("--force can only be used with --clear.");
+                }
+
+                if (selectedActionCount == 0 && string.IsNullOrWhiteSpace(tableName))
+                {
+                    throw new UserFacingException("Specify a table name or use --clear to clear all table notes.");
+                }
+
+                if (string.IsNullOrWhiteSpace(tableName))
+                {
+                    if (addNote is not null || noteId is not null || deleteNote is not null)
+                    {
+                        throw new UserFacingException("A table name is required for --add, --id, and --delete.");
+                    }
+
+                    if (!clearNotes)
+                    {
+                        throw new UserFacingException("Specify a table name or use --clear to clear all table notes.");
+                    }
+
+                    if (!string.IsNullOrWhiteSpace(clusterReference) || !string.IsNullOrWhiteSpace(databaseName))
+                    {
+                        throw new UserFacingException("--cluster and --database can only be used when a table name is provided.");
+                    }
+                }
+
+                var config = await runtime.ConfigStore.LoadAsync(ct);
+
+                if (clearNotes && string.IsNullOrWhiteSpace(tableName))
+                {
+                    if (!force && !await runtime.ConfirmationPrompt.ConfirmAsync("Clear all table notes?", ct))
+                    {
+                        return new CliOutput { Message = "Operation cancelled." };
+                    }
+
+                    return await runtime.TableOfflineDataManager.ClearTableNotesAsync(config, null, null, null, ct);
+                }
+
+                var resolvedCluster = runtime.ConnectionResolver.ResolveCluster(config, clusterReference);
+                var resolvedDatabase = runtime.ConnectionResolver.ResolveDatabase(config, resolvedCluster.Url, databaseName);
+
+                if (addNote is not null)
+                {
+                    return await runtime.TableOfflineDataManager.AddTableNoteAsync(
+                        config,
+                        resolvedCluster.Url,
+                        resolvedDatabase,
+                        tableName!,
+                        addNote,
+                        ct);
+                }
+
+                if (noteId is not null)
+                {
+                    return await runtime.TableOfflineDataManager.ShowTableNotesAsync(
+                        config,
+                        resolvedCluster.Url,
+                        resolvedDatabase,
+                        tableName!,
+                        noteId,
+                        ct);
+                }
+
+                if (deleteNote is not null)
+                {
+                    return await runtime.TableOfflineDataManager.DeleteTableNoteAsync(
+                        config,
+                        resolvedCluster.Url,
+                        resolvedDatabase,
+                        tableName!,
+                        deleteNote.Value,
+                        ct);
+                }
+
+                if (clearNotes)
+                {
+                    if (!force && !await runtime.ConfirmationPrompt.ConfirmAsync($"Clear all notes for table '{tableName}'?", ct))
+                    {
+                        return new CliOutput { Message = "Operation cancelled." };
+                    }
+
+                    return await runtime.TableOfflineDataManager.ClearTableNotesAsync(
                         config,
                         resolvedCluster.Url,
                         resolvedDatabase,
                         tableName,
-                        ct)
-                };
+                        ct);
+                }
+
+                return await runtime.TableOfflineDataManager.ShowTableNotesAsync(
+                    config,
+                    resolvedCluster.Url,
+                    resolvedDatabase,
+                    tableName!,
+                    null,
+                    ct);
             }, cancellationToken);
         });
 
         tableCommand.Add(listCommand);
         tableCommand.Add(showCommand);
+        tableCommand.Add(notesCommand);
         return tableCommand;
     }
 
@@ -654,6 +963,24 @@ public static class CommandFactory
         return option;
     }
 
+    private static Option<FileInfo?> CreateOfflineDataFileOption(string name, string description)
+    {
+        return new Option<FileInfo?>(name)
+        {
+            Description = description
+        };
+    }
+
+    private static Option<bool> CreateForceOption(string description)
+    {
+        var option = new Option<bool>("--force")
+        {
+            Description = $"{description} Alias: -f."
+        };
+        option.Aliases.Add("-f");
+        return option;
+    }
+
     private static int GetPreferredColumnIndex(TabularData table, string preferredColumnName)
     {
         if (table.TryGetColumnIndex(preferredColumnName, out var index))
@@ -685,5 +1012,20 @@ public static class CommandFactory
     private static string EscapeKustoLiteral(string input)
     {
         return KustoCommandText.EscapeSingleQuotedLiteral(input);
+    }
+
+    private static int CountSpecified(params bool[] values)
+    {
+        return values.Count(value => value);
+    }
+
+    private static void EnsureNoScopedTableOptions(string? tableName, string? clusterReference, string? databaseName, string optionName)
+    {
+        if (!string.IsNullOrWhiteSpace(tableName) ||
+            !string.IsNullOrWhiteSpace(clusterReference) ||
+            !string.IsNullOrWhiteSpace(databaseName))
+        {
+            throw new UserFacingException($"{optionName} can't be combined with a table name, --cluster, or --database.");
+        }
     }
 }

--- a/src/Kusto.Cli/ConfirmationPrompt.cs
+++ b/src/Kusto.Cli/ConfirmationPrompt.cs
@@ -1,0 +1,19 @@
+namespace Kusto.Cli;
+
+public sealed class ConsoleConfirmationPrompt(TextReader input, TextWriter output) : IConfirmationPrompt
+{
+    private readonly TextReader _input = input;
+    private readonly TextWriter _output = output;
+
+    public async Task<bool> ConfirmAsync(string prompt, CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(prompt);
+
+        await _output.WriteAsync($"{prompt} [y/N] ");
+        await _output.FlushAsync(cancellationToken);
+        var response = await _input.ReadLineAsync(cancellationToken);
+        return response is not null &&
+               (string.Equals(response.Trim(), "y", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(response.Trim(), "yes", StringComparison.OrdinalIgnoreCase));
+    }
+}

--- a/src/Kusto.Cli/Contracts.cs
+++ b/src/Kusto.Cli/Contracts.cs
@@ -42,19 +42,66 @@ public interface IOutputFormatter
 
 public interface ITableSchemaProvider
 {
-    Task<Dictionary<string, string?>> GetTablePropertiesAsync(
+    Task<TableSchemaDetails> GetTableSchemaDetailsAsync(
         KustoConfig config,
         string clusterUrl,
         string database,
         string tableName,
+        bool refreshOfflineData,
         CancellationToken cancellationToken);
 }
 
-public enum OutputFormat
+public interface ITableOfflineDataManager
 {
-    Human,
-    Json,
-    Markdown
+    Task<CliOutput> ShowTableNotesAsync(
+        KustoConfig config,
+        string clusterUrl,
+        string database,
+        string tableName,
+        int? noteId,
+        CancellationToken cancellationToken);
+    Task<CliOutput> AddTableNoteAsync(
+        KustoConfig config,
+        string clusterUrl,
+        string database,
+        string tableName,
+        string note,
+        CancellationToken cancellationToken);
+    Task<CliOutput> DeleteTableNoteAsync(
+        KustoConfig config,
+        string clusterUrl,
+        string database,
+        string tableName,
+        int noteId,
+        CancellationToken cancellationToken);
+    Task<CliOutput> ClearTableNotesAsync(
+        KustoConfig config,
+        string? clusterUrl,
+        string? database,
+        string? tableName,
+        CancellationToken cancellationToken);
+    Task<CliOutput> ExportOfflineDataAsync(
+        KustoConfig config,
+        string filePath,
+        CancellationToken cancellationToken);
+    Task<CliOutput> ImportOfflineDataAsync(
+        KustoConfig config,
+        string filePath,
+        CancellationToken cancellationToken);
+    Task<CliOutput> PurgeOfflineDataAsync(
+        KustoConfig config,
+        CancellationToken cancellationToken);
+    Task<CliOutput> ClearOfflineDataAsync(
+        KustoConfig config,
+        string? clusterUrl,
+        string? database,
+        string? tableName,
+        CancellationToken cancellationToken);
+}
+
+public interface IConfirmationPrompt
+{
+    Task<bool> ConfirmAsync(string prompt, CancellationToken cancellationToken);
 }
 
 public sealed class CliRuntime(
@@ -65,6 +112,8 @@ public sealed class CliRuntime(
     IKustoConnectionResolver connectionResolver,
     IKustoService kustoService,
     ITableSchemaProvider tableSchemaProvider,
+    ITableOfflineDataManager tableOfflineDataManager,
+    IConfirmationPrompt confirmationPrompt,
     IOutputFormatter outputFormatter) : IDisposable
 {
     public ILoggerFactory LoggerFactory { get; } = loggerFactory;
@@ -74,6 +123,8 @@ public sealed class CliRuntime(
     public IKustoConnectionResolver ConnectionResolver { get; } = connectionResolver;
     public IKustoService KustoService { get; } = kustoService;
     public ITableSchemaProvider TableSchemaProvider { get; } = tableSchemaProvider;
+    public ITableOfflineDataManager TableOfflineDataManager { get; } = tableOfflineDataManager;
+    public IConfirmationPrompt ConfirmationPrompt { get; } = confirmationPrompt;
     public IOutputFormatter OutputFormatter { get; } = outputFormatter;
 
     public void Dispose()
@@ -81,4 +132,11 @@ public sealed class CliRuntime(
         HttpClient.Dispose();
         LoggerFactory.Dispose();
     }
+}
+
+public enum OutputFormat
+{
+    Human,
+    Json,
+    Markdown
 }

--- a/src/Kusto.Cli/DatabaseSchemaJson.cs
+++ b/src/Kusto.Cli/DatabaseSchemaJson.cs
@@ -1,0 +1,384 @@
+using System.Globalization;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace Kusto.Cli;
+
+internal static class DatabaseSchemaJson
+{
+    public static TableSchemaDetails BuildTableSchemaDetails(
+        string schemaJson,
+        string database,
+        string tableName,
+        IReadOnlyList<string>? notes)
+    {
+        try
+        {
+            using var document = JsonDocument.Parse(schemaJson);
+            var databaseElement = FindDatabaseElement(document.RootElement, database);
+            if (!TryGetNamedProperty(databaseElement, "Tables", out var tablesElement) ||
+                tablesElement.ValueKind != JsonValueKind.Object ||
+                !TryGetNamedProperty(tablesElement, tableName, out var tableElement) ||
+                tableElement.ValueKind != JsonValueKind.Object)
+            {
+                throw new UserFacingException($"Table '{tableName}' was not found.");
+            }
+
+            if (!TryGetNamedProperty(tableElement, "OrderedColumns", out var orderedColumnsElement) ||
+                orderedColumnsElement.ValueKind != JsonValueKind.Array)
+            {
+                throw new UserFacingException($"Kusto returned a schema for table '{tableName}' without OrderedColumns.");
+            }
+
+            var properties = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["TableName"] = GetStringProperty(tableElement, "Name") ?? tableName,
+                ["DatabaseName"] = GetStringProperty(databaseElement, "Name") ?? database,
+                ["ColumnCount"] = orderedColumnsElement.GetArrayLength().ToString(CultureInfo.InvariantCulture)
+            };
+
+            AddOptionalProperty(properties, tableElement, "Folder");
+            AddOptionalProperty(properties, tableElement, "DocString");
+            if (notes is { Count: > 0 })
+            {
+                properties["NoteCount"] = notes.Count.ToString(CultureInfo.InvariantCulture);
+            }
+
+            return new TableSchemaDetails
+            {
+                Properties = properties,
+                Columns = BuildColumnsTable(orderedColumnsElement),
+                NotesMessage = BuildNotesMessage(notes)
+            };
+        }
+        catch (UserFacingException)
+        {
+            throw;
+        }
+        catch (JsonException ex)
+        {
+            throw new UserFacingException("Kusto returned an unexpected database schema format.", ex);
+        }
+    }
+
+    public static string ExtractSchemaJson(TabularData result)
+    {
+        if (result.Rows.Count == 0)
+        {
+            throw new UserFacingException("Kusto did not return a database schema.");
+        }
+
+        var row = result.Rows[0];
+        if (TryGetPreferredValue(result, row, "DatabaseSchema", out var preferredValue) ||
+            TryGetPreferredValue(result, row, "Schema", out preferredValue))
+        {
+            return preferredValue!;
+        }
+
+        for (var i = 0; i < row.Count; i++)
+        {
+            if (!string.IsNullOrWhiteSpace(row[i]))
+            {
+                return row[i]!;
+            }
+        }
+
+        throw new UserFacingException("Kusto returned an empty database schema payload.");
+    }
+
+    public static string? ExtractDatabaseSchemaVersion(string schemaJson, string database)
+    {
+        try
+        {
+            using var document = JsonDocument.Parse(schemaJson);
+            var databaseElement = FindDatabaseElement(document.RootElement, database);
+
+            var explicitVersion = GetStringProperty(databaseElement, "Version");
+            if (!string.IsNullOrWhiteSpace(explicitVersion))
+            {
+                return explicitVersion;
+            }
+
+            if (TryGetNamedProperty(databaseElement, "MajorVersion", out var majorVersionElement) &&
+                TryGetNamedProperty(databaseElement, "MinorVersion", out var minorVersionElement) &&
+                TryGetInt32(majorVersionElement, out var majorVersion) &&
+                TryGetInt32(minorVersionElement, out var minorVersion))
+            {
+                return $"v{majorVersion}.{minorVersion}";
+            }
+
+            return null;
+        }
+        catch (JsonException ex)
+        {
+            throw new UserFacingException("Kusto returned an unexpected database schema format.", ex);
+        }
+    }
+
+    public static IReadOnlyList<string> GetTableNames(string schemaJson, string database)
+    {
+        if (string.IsNullOrWhiteSpace(schemaJson))
+        {
+            return [];
+        }
+
+        try
+        {
+            using var document = JsonDocument.Parse(schemaJson);
+            var databaseElement = FindDatabaseElement(document.RootElement, database);
+            if (!TryGetNamedProperty(databaseElement, "Tables", out var tablesElement) ||
+                tablesElement.ValueKind != JsonValueKind.Object)
+            {
+                return [];
+            }
+
+            return tablesElement
+                .EnumerateObject()
+                .Select(property => property.Name)
+                .Where(name => !string.IsNullOrWhiteSpace(name))
+                .ToList();
+        }
+        catch (JsonException ex)
+        {
+            throw new UserFacingException("Kusto returned an unexpected database schema format.", ex);
+        }
+    }
+
+    public static string RemoveTable(string schemaJson, string database, string tableName)
+    {
+        if (string.IsNullOrWhiteSpace(schemaJson))
+        {
+            return string.Empty;
+        }
+
+        JsonNode? rootNode;
+        try
+        {
+            rootNode = JsonNode.Parse(schemaJson);
+        }
+        catch (JsonException ex)
+        {
+            throw new UserFacingException("Kusto returned an unexpected database schema format.", ex);
+        }
+
+        if (rootNode is null)
+        {
+            throw new UserFacingException("Kusto returned an empty database schema payload.");
+        }
+
+        var tablesNode = FindTablesNode(rootNode, database);
+        if (tablesNode is not null)
+        {
+            var keyToRemove = tablesNode
+                .Select(pair => pair.Key)
+                .FirstOrDefault(key => string.Equals(key, tableName, StringComparison.OrdinalIgnoreCase));
+
+            if (!string.IsNullOrWhiteSpace(keyToRemove))
+            {
+                tablesNode.Remove(keyToRemove);
+            }
+
+            if (tablesNode.Count == 0)
+            {
+                return string.Empty;
+            }
+        }
+
+        return rootNode.ToJsonString(new JsonSerializerOptions { WriteIndented = true });
+    }
+
+    private static TabularData BuildColumnsTable(JsonElement orderedColumnsElement)
+    {
+        var rows = new List<IReadOnlyList<string?>>();
+        foreach (var columnElement in orderedColumnsElement.EnumerateArray())
+        {
+            rows.Add(
+            [
+                GetStringProperty(columnElement, "Name"),
+                GetStringProperty(columnElement, "Type") ?? GetStringProperty(columnElement, "DataType"),
+                GetStringProperty(columnElement, "CslType"),
+                GetStringProperty(columnElement, "DocString")
+            ]);
+        }
+
+        return new TabularData(["Name", "Type", "CslType", "DocString"], rows);
+    }
+
+    private static string? BuildNotesMessage(IReadOnlyList<string>? notes)
+    {
+        if (notes is not { Count: > 0 })
+        {
+            return null;
+        }
+
+        var buffer = new StringBuilder();
+        buffer.AppendLine("Table notes:");
+        for (var i = 0; i < notes.Count; i++)
+        {
+            buffer.Append(i + 1);
+            buffer.Append(". ");
+            buffer.AppendLine(notes[i]);
+        }
+
+        return buffer.ToString().TrimEnd();
+    }
+
+    private static JsonElement FindDatabaseElement(JsonElement rootElement, string database)
+    {
+        if (TryGetNamedProperty(rootElement, "Databases", out var databasesElement) &&
+            databasesElement.ValueKind == JsonValueKind.Object)
+        {
+            if (TryGetNamedProperty(databasesElement, database, out var databaseElement))
+            {
+                return databaseElement;
+            }
+
+            if (databasesElement.EnumerateObject().FirstOrDefault() is { Name: not null } firstDatabase)
+            {
+                return firstDatabase.Value;
+            }
+        }
+
+        if (TryGetNamedProperty(rootElement, "Tables", out _))
+        {
+            return rootElement;
+        }
+
+        throw new UserFacingException($"Kusto did not return a schema for database '{database}'.");
+    }
+
+    private static JsonObject? FindTablesNode(JsonNode rootNode, string database)
+    {
+        if (rootNode is not JsonObject rootObject)
+        {
+            return null;
+        }
+
+        if (TryGetNamedNode(rootObject, "Databases", out var databasesNode) &&
+            databasesNode is JsonObject databasesObject)
+        {
+            if (TryGetNamedNode(databasesObject, database, out var databaseNode) &&
+                databaseNode is JsonObject databaseObject &&
+                TryGetNamedNode(databaseObject, "Tables", out var tablesNode) &&
+                tablesNode is JsonObject tablesObject)
+            {
+                return tablesObject;
+            }
+
+            var firstDatabase = databasesObject.FirstOrDefault(pair => pair.Value is JsonObject);
+            if (firstDatabase.Value is JsonObject firstDatabaseObject &&
+                TryGetNamedNode(firstDatabaseObject, "Tables", out var firstTablesNode) &&
+                firstTablesNode is JsonObject firstTablesObject)
+            {
+                return firstTablesObject;
+            }
+        }
+
+        if (TryGetNamedNode(rootObject, "Tables", out var directTablesNode) &&
+            directTablesNode is JsonObject directTablesObject)
+        {
+            return directTablesObject;
+        }
+
+        return null;
+    }
+
+    private static bool TryGetNamedProperty(JsonElement element, string propertyName, out JsonElement value)
+    {
+        if (element.ValueKind != JsonValueKind.Object)
+        {
+            value = default;
+            return false;
+        }
+
+        if (element.TryGetProperty(propertyName, out value))
+        {
+            return true;
+        }
+
+        foreach (var property in element.EnumerateObject())
+        {
+            if (string.Equals(property.Name, propertyName, StringComparison.OrdinalIgnoreCase))
+            {
+                value = property.Value;
+                return true;
+            }
+        }
+
+        value = default;
+        return false;
+    }
+
+    private static bool TryGetNamedNode(JsonObject obj, string propertyName, out JsonNode? value)
+    {
+        if (obj.TryGetPropertyValue(propertyName, out value))
+        {
+            return true;
+        }
+
+        foreach (var pair in obj)
+        {
+            if (string.Equals(pair.Key, propertyName, StringComparison.OrdinalIgnoreCase))
+            {
+                value = pair.Value;
+                return true;
+            }
+        }
+
+        value = null;
+        return false;
+    }
+
+    private static string? GetStringProperty(JsonElement element, string propertyName)
+    {
+        return TryGetNamedProperty(element, propertyName, out var value) && value.ValueKind == JsonValueKind.String
+            ? value.GetString()
+            : null;
+    }
+
+    private static bool TryGetInt32(JsonElement element, out int value)
+    {
+        if (element.ValueKind == JsonValueKind.Number)
+        {
+            return element.TryGetInt32(out value);
+        }
+
+        if (element.ValueKind == JsonValueKind.String &&
+            int.TryParse(element.GetString(), NumberStyles.Integer, CultureInfo.InvariantCulture, out value))
+        {
+            return true;
+        }
+
+        value = default;
+        return false;
+    }
+
+    private static bool TryGetPreferredValue(
+        TabularData result,
+        IReadOnlyList<string?> row,
+        string preferredColumnName,
+        out string? value)
+    {
+        value = null;
+        if (!result.TryGetColumnIndex(preferredColumnName, out var columnIndex) ||
+            columnIndex < 0 ||
+            columnIndex >= row.Count ||
+            string.IsNullOrWhiteSpace(row[columnIndex]))
+        {
+            return false;
+        }
+
+        value = row[columnIndex];
+        return true;
+    }
+
+    private static void AddOptionalProperty(IDictionary<string, string?> properties, JsonElement element, string propertyName)
+    {
+        var value = GetStringProperty(element, propertyName);
+        if (!string.IsNullOrWhiteSpace(value))
+        {
+            properties[propertyName] = value;
+        }
+    }
+}

--- a/src/Kusto.Cli/KustoJsonSerializerContext.cs
+++ b/src/Kusto.Cli/KustoJsonSerializerContext.cs
@@ -15,6 +15,7 @@ namespace Kusto.Cli;
 [JsonSerializable(typeof(KustoConfig))]
 [JsonSerializable(typeof(SchemaCacheConfig))]
 [JsonSerializable(typeof(SchemaCacheOverride))]
+[JsonSerializable(typeof(OfflineTableDataExport))]
 [JsonSerializable(typeof(KustoRequestPayload))]
 [JsonSerializable(typeof(KustoRequestProperties))]
 [JsonSerializable(typeof(KustoResponsePayload))]
@@ -33,6 +34,8 @@ namespace Kusto.Cli;
 [JsonSerializable(typeof(QueryCrossClusterStatistics))]
 [JsonSerializable(typeof(Dictionary<string, QueryCrossClusterStatistics>))]
 [JsonSerializable(typeof(DatabaseSchemaCacheEntry))]
+[JsonSerializable(typeof(Dictionary<string, List<string>>))]
+[JsonSerializable(typeof(List<string>))]
 [JsonSerializable(typeof(TabularData))]
 internal sealed partial class KustoJsonSerializerContext : JsonSerializerContext
 {

--- a/src/Kusto.Cli/Models.cs
+++ b/src/Kusto.Cli/Models.cs
@@ -53,6 +53,14 @@ public sealed class TabularData(IReadOnlyList<string> columns, IReadOnlyList<IRe
     }
 }
 
+public sealed class TableSchemaDetails
+{
+    public Dictionary<string, string?> Properties { get; init; } = new(StringComparer.OrdinalIgnoreCase);
+    public TabularData Columns { get; init; } = TabularData.Empty;
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? NotesMessage { get; init; }
+}
+
 public sealed class QueryExecutionResult(
     TabularData table,
     string? webExplorerUrl,
@@ -200,6 +208,12 @@ public sealed class SchemaCacheOverride
     public int TtlSeconds { get; set; } = SchemaCacheSettingsResolver.DefaultTtlSeconds;
 }
 
+public sealed class OfflineTableDataExport
+{
+    public int FormatVersion { get; set; } = 1;
+    public List<DatabaseSchemaCacheEntry> Entries { get; set; } = [];
+}
+
 public sealed class ResolvedCluster(string? name, string url)
 {
     public string? Name { get; } = name;
@@ -246,7 +260,7 @@ internal sealed class ParsedKustoTable(string? tableName, string? tableKind, IRe
     public IReadOnlyList<IReadOnlyList<string?>> Rows { get; } = rows;
 }
 
-internal sealed class DatabaseSchemaCacheEntry
+public sealed class DatabaseSchemaCacheEntry
 {
     public int CacheFormatVersion { get; set; } = 1;
     public string ClusterUrl { get; set; } = string.Empty;
@@ -254,6 +268,7 @@ internal sealed class DatabaseSchemaCacheEntry
     public DateTimeOffset CachedAtUtc { get; set; }
     public string? SchemaVersion { get; set; }
     public string SchemaJson { get; set; } = string.Empty;
+    public Dictionary<string, List<string>> TableNotes { get; set; } = new(StringComparer.OrdinalIgnoreCase);
 }
 
 internal enum QueryChartKind

--- a/src/Kusto.Cli/OfflineTableDataStore.cs
+++ b/src/Kusto.Cli/OfflineTableDataStore.cs
@@ -1,0 +1,210 @@
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+
+namespace Kusto.Cli;
+
+public sealed class OfflineTableDataStore(
+    SchemaCacheSettingsResolver settingsResolver,
+    ILogger<OfflineTableDataStore> logger)
+{
+    private const int CacheFormatVersion = 1;
+
+    private readonly SchemaCacheSettingsResolver _settingsResolver = settingsResolver;
+    private readonly ILogger<OfflineTableDataStore> _logger = logger;
+
+    public async Task<DatabaseSchemaCacheEntry?> TryReadEntryAsync(
+        KustoConfig config,
+        string clusterUrl,
+        string database,
+        CancellationToken cancellationToken)
+    {
+        var normalizedClusterUrl = ClusterUtilities.NormalizeClusterUrl(clusterUrl);
+        var cacheDirectory = _settingsResolver.ResolveCacheDirectory(config);
+        var cachePath = BuildCachePath(cacheDirectory, normalizedClusterUrl, database);
+        return await TryReadEntryFromPathAsync(cachePath, cancellationToken);
+    }
+
+    public async Task<IReadOnlyList<DatabaseSchemaCacheEntry>> ReadAllEntriesAsync(
+        KustoConfig config,
+        CancellationToken cancellationToken)
+    {
+        var cacheDirectory = _settingsResolver.ResolveCacheDirectory(config);
+        if (!Directory.Exists(cacheDirectory))
+        {
+            return [];
+        }
+
+        var entries = new List<DatabaseSchemaCacheEntry>();
+        foreach (var path in Directory.EnumerateFiles(cacheDirectory, "*.json", SearchOption.TopDirectoryOnly))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var entry = await TryReadEntryFromPathAsync(path, cancellationToken);
+            if (entry is not null)
+            {
+                entries.Add(entry);
+            }
+        }
+
+        return entries;
+    }
+
+    public async Task WriteEntryAsync(
+        KustoConfig config,
+        DatabaseSchemaCacheEntry cacheEntry,
+        CancellationToken cancellationToken)
+    {
+        var normalizedClusterUrl = ClusterUtilities.NormalizeClusterUrl(cacheEntry.ClusterUrl);
+        var cacheDirectory = _settingsResolver.ResolveCacheDirectory(config);
+        var cachePath = BuildCachePath(cacheDirectory, normalizedClusterUrl, cacheEntry.DatabaseName);
+        var directory = Path.GetDirectoryName(cachePath);
+        if (string.IsNullOrWhiteSpace(directory))
+        {
+            return;
+        }
+
+        cacheEntry.CacheFormatVersion = CacheFormatVersion;
+        cacheEntry.ClusterUrl = normalizedClusterUrl;
+        cacheEntry.DatabaseName = cacheEntry.DatabaseName.Trim();
+        cacheEntry.TableNotes = NormalizeNotes(cacheEntry.TableNotes);
+
+        var temporaryPath = Path.Combine(directory, $"{Path.GetFileName(cachePath)}.{Guid.NewGuid():N}.tmp");
+
+        try
+        {
+            Directory.CreateDirectory(directory);
+            await using (var stream = File.Create(temporaryPath))
+            {
+                await JsonSerializer.SerializeAsync(
+                    stream,
+                    cacheEntry,
+                    KustoJsonSerializerContext.Default.DatabaseSchemaCacheEntry,
+                    cancellationToken);
+            }
+
+            File.Move(temporaryPath, cachePath, true);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            _logger.LogWarning(ex, "Failed to write offline table data entry to {CachePath}.", cachePath);
+        }
+        finally
+        {
+            TryDeleteTemporaryFile(temporaryPath);
+        }
+    }
+
+    public Task DeleteEntryAsync(
+        KustoConfig config,
+        string clusterUrl,
+        string database,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var normalizedClusterUrl = ClusterUtilities.NormalizeClusterUrl(clusterUrl);
+        var cacheDirectory = _settingsResolver.ResolveCacheDirectory(config);
+        var cachePath = BuildCachePath(cacheDirectory, normalizedClusterUrl, database);
+
+        try
+        {
+            if (File.Exists(cachePath))
+            {
+                File.Delete(cachePath);
+            }
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            _logger.LogWarning(ex, "Failed to delete offline table data entry at {CachePath}.", cachePath);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    private async Task<DatabaseSchemaCacheEntry?> TryReadEntryFromPathAsync(string cachePath, CancellationToken cancellationToken)
+    {
+        if (!File.Exists(cachePath))
+        {
+            return null;
+        }
+
+        try
+        {
+            await using var stream = File.OpenRead(cachePath);
+            var cacheEntry = await JsonSerializer.DeserializeAsync(
+                stream,
+                KustoJsonSerializerContext.Default.DatabaseSchemaCacheEntry,
+                cancellationToken);
+
+            if (cacheEntry is null ||
+                cacheEntry.CacheFormatVersion != CacheFormatVersion ||
+                string.IsNullOrWhiteSpace(cacheEntry.ClusterUrl) ||
+                string.IsNullOrWhiteSpace(cacheEntry.DatabaseName))
+            {
+                return null;
+            }
+
+            cacheEntry.ClusterUrl = ClusterUtilities.NormalizeClusterUrl(cacheEntry.ClusterUrl);
+            cacheEntry.DatabaseName = cacheEntry.DatabaseName.Trim();
+            cacheEntry.TableNotes = NormalizeNotes(cacheEntry.TableNotes);
+            return cacheEntry;
+        }
+        catch (Exception ex) when (ex is JsonException or IOException or UnauthorizedAccessException or UserFacingException)
+        {
+            _logger.LogWarning(ex, "Ignoring unreadable offline table data entry at {CachePath}.", cachePath);
+            return null;
+        }
+    }
+
+    private static Dictionary<string, List<string>> NormalizeNotes(Dictionary<string, List<string>>? tableNotes)
+    {
+        var normalized = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
+        if (tableNotes is null)
+        {
+            return normalized;
+        }
+
+        foreach (var pair in tableNotes)
+        {
+            if (string.IsNullOrWhiteSpace(pair.Key))
+            {
+                continue;
+            }
+
+            var notes = pair.Value?
+                .Where(note => !string.IsNullOrWhiteSpace(note))
+                .Select(note => note.Trim())
+                .ToList();
+
+            if (notes is { Count: > 0 })
+            {
+                normalized[pair.Key.Trim()] = notes;
+            }
+        }
+
+        return normalized;
+    }
+
+    private static string BuildCachePath(string cacheDirectory, string clusterUrl, string database)
+    {
+        var keyBytes = Encoding.UTF8.GetBytes($"database-schema:v{CacheFormatVersion}:{clusterUrl.ToLowerInvariant()}|{database.ToLowerInvariant()}");
+        var hash = Convert.ToHexString(SHA256.HashData(keyBytes)).ToLowerInvariant();
+        return Path.Combine(cacheDirectory, $"{hash}.json");
+    }
+
+    private void TryDeleteTemporaryFile(string temporaryPath)
+    {
+        try
+        {
+            if (File.Exists(temporaryPath))
+            {
+                File.Delete(temporaryPath);
+            }
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            _logger.LogDebug(ex, "Failed to clean up temporary offline table data file {TemporaryPath}.", temporaryPath);
+        }
+    }
+}

--- a/src/Kusto.Cli/SchemaCacheSettingsResolver.cs
+++ b/src/Kusto.Cli/SchemaCacheSettingsResolver.cs
@@ -37,6 +37,13 @@ public sealed class SchemaCacheSettingsResolver(
         return new ResolvedSchemaCacheSettings(true, cacheDirectory, TimeSpan.FromSeconds(ttlSeconds));
     }
 
+    public string ResolveCacheDirectory(KustoConfig config)
+    {
+        ArgumentNullException.ThrowIfNull(config);
+        var cacheConfig = config.SchemaCache ?? new SchemaCacheConfig();
+        return ResolveCacheDirectory(cacheConfig);
+    }
+
     private bool ResolveEnabled(bool configuredEnabled)
     {
         var value = _getEnvironmentVariable(CacheEnabledEnvironmentVariable);

--- a/src/Kusto.Cli/TableOfflineDataManager.cs
+++ b/src/Kusto.Cli/TableOfflineDataManager.cs
@@ -1,0 +1,519 @@
+using System.Globalization;
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+
+namespace Kusto.Cli;
+
+public sealed class TableOfflineDataManager(
+    IKustoService kustoService,
+    OfflineTableDataStore offlineTableDataStore,
+    ILogger<TableOfflineDataManager> logger) : ITableOfflineDataManager
+{
+    private readonly IKustoService _kustoService = kustoService;
+    private readonly OfflineTableDataStore _offlineTableDataStore = offlineTableDataStore;
+    private readonly ILogger<TableOfflineDataManager> _logger = logger;
+
+    public async Task<CliOutput> ShowTableNotesAsync(
+        KustoConfig config,
+        string clusterUrl,
+        string database,
+        string tableName,
+        int? noteId,
+        CancellationToken cancellationToken)
+    {
+        var entry = await _offlineTableDataStore.TryReadEntryAsync(config, clusterUrl, database, cancellationToken);
+        var notes = GetNotes(entry, tableName);
+
+        if (noteId is int id)
+        {
+            EnsurePositiveId(id, "--id");
+            if (id > notes.Count)
+            {
+                throw new UserFacingException($"Note {id} was not found for table '{tableName}'.");
+            }
+
+            return new CliOutput
+            {
+                Table = BuildNotesTable([(id, notes[id - 1])])
+            };
+        }
+
+        if (notes.Count == 0)
+        {
+            return new CliOutput
+            {
+                Message = $"No notes found for table '{tableName}'."
+            };
+        }
+
+        return new CliOutput
+        {
+            Table = BuildNotesTable(notes.Select((note, index) => (index + 1, note)))
+        };
+    }
+
+    public async Task<CliOutput> AddTableNoteAsync(
+        KustoConfig config,
+        string clusterUrl,
+        string database,
+        string tableName,
+        string note,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(note))
+        {
+            throw new UserFacingException("The --add value cannot be empty.");
+        }
+
+        var normalizedClusterUrl = ClusterUtilities.NormalizeClusterUrl(clusterUrl);
+        var entry = await _offlineTableDataStore.TryReadEntryAsync(config, normalizedClusterUrl, database, cancellationToken) ??
+            CreateEmptyEntry(normalizedClusterUrl, database);
+
+        if (!entry.TableNotes.TryGetValue(tableName, out var notes))
+        {
+            notes = [];
+            entry.TableNotes[tableName] = notes;
+        }
+
+        notes.Add(note.Trim());
+        await _offlineTableDataStore.WriteEntryAsync(config, entry, cancellationToken);
+
+        return new CliOutput
+        {
+            Message = $"Added note {notes.Count.ToString(CultureInfo.InvariantCulture)} for table '{tableName}'."
+        };
+    }
+
+    public async Task<CliOutput> DeleteTableNoteAsync(
+        KustoConfig config,
+        string clusterUrl,
+        string database,
+        string tableName,
+        int noteId,
+        CancellationToken cancellationToken)
+    {
+        EnsurePositiveId(noteId, "--delete");
+
+        var normalizedClusterUrl = ClusterUtilities.NormalizeClusterUrl(clusterUrl);
+        var entry = await _offlineTableDataStore.TryReadEntryAsync(config, normalizedClusterUrl, database, cancellationToken);
+        var notes = GetNotes(entry, tableName);
+        if (noteId > notes.Count)
+        {
+            throw new UserFacingException($"Note {noteId} was not found for table '{tableName}'.");
+        }
+
+        notes.RemoveAt(noteId - 1);
+        if (notes.Count == 0 && entry is not null)
+        {
+            entry.TableNotes.Remove(tableName);
+        }
+
+        await PersistOrDeleteAsync(config, entry, cancellationToken);
+        return new CliOutput
+        {
+            Message = $"Deleted note {noteId.ToString(CultureInfo.InvariantCulture)} from table '{tableName}'."
+        };
+    }
+
+    public async Task<CliOutput> ClearTableNotesAsync(
+        KustoConfig config,
+        string? clusterUrl,
+        string? database,
+        string? tableName,
+        CancellationToken cancellationToken)
+    {
+        if (!string.IsNullOrWhiteSpace(tableName))
+        {
+            var normalizedClusterUrl = ClusterUtilities.NormalizeClusterUrl(clusterUrl!);
+            var entry = await _offlineTableDataStore.TryReadEntryAsync(config, normalizedClusterUrl, database!, cancellationToken);
+            var notes = GetNotes(entry, tableName);
+            if (notes.Count == 0)
+            {
+                return new CliOutput
+                {
+                    Message = $"No notes found for table '{tableName}'."
+                };
+            }
+
+            entry!.TableNotes.Remove(tableName);
+            await PersistOrDeleteAsync(config, entry, cancellationToken);
+            return new CliOutput
+            {
+                Message = $"Cleared {notes.Count.ToString(CultureInfo.InvariantCulture)} notes for table '{tableName}'."
+            };
+        }
+
+        var entries = await _offlineTableDataStore.ReadAllEntriesAsync(config, cancellationToken);
+        var removedNotes = 0;
+        foreach (var entry in entries)
+        {
+            removedNotes += entry.TableNotes.Values.Sum(notes => notes.Count);
+            entry.TableNotes.Clear();
+            await PersistOrDeleteAsync(config, entry, cancellationToken);
+        }
+
+        return new CliOutput
+        {
+            Message = removedNotes == 0
+                ? "No table notes were found."
+                : $"Cleared {removedNotes.ToString(CultureInfo.InvariantCulture)} table notes."
+        };
+    }
+
+    public async Task<CliOutput> ExportOfflineDataAsync(
+        KustoConfig config,
+        string filePath,
+        CancellationToken cancellationToken)
+    {
+        var exportPath = Path.GetFullPath(filePath);
+        var directory = Path.GetDirectoryName(exportPath);
+        if (!string.IsNullOrWhiteSpace(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+
+        var entries = await _offlineTableDataStore.ReadAllEntriesAsync(config, cancellationToken);
+        var payload = new OfflineTableDataExport
+        {
+            Entries =
+            [
+                .. entries
+                    .OrderBy(entry => entry.ClusterUrl, StringComparer.OrdinalIgnoreCase)
+                    .ThenBy(entry => entry.DatabaseName, StringComparer.OrdinalIgnoreCase)
+            ]
+        };
+
+        await using var stream = File.Create(exportPath);
+        await JsonSerializer.SerializeAsync(
+            stream,
+            payload,
+            KustoJsonSerializerContext.Default.OfflineTableDataExport,
+            cancellationToken);
+
+        return new CliOutput
+        {
+            Message = $"Exported {payload.Entries.Count.ToString(CultureInfo.InvariantCulture)} offline data entries to '{exportPath}'."
+        };
+    }
+
+    public async Task<CliOutput> ImportOfflineDataAsync(
+        KustoConfig config,
+        string filePath,
+        CancellationToken cancellationToken)
+    {
+        var importPath = Path.GetFullPath(filePath);
+        if (!File.Exists(importPath))
+        {
+            throw new UserFacingException($"Offline data file '{importPath}' was not found.");
+        }
+
+        await using var stream = File.OpenRead(importPath);
+        var payload = await JsonSerializer.DeserializeAsync(
+            stream,
+            KustoJsonSerializerContext.Default.OfflineTableDataExport,
+            cancellationToken);
+
+        if (payload is null)
+        {
+            throw new UserFacingException("The offline data import file is empty.");
+        }
+
+        if (payload.FormatVersion != 1)
+        {
+            throw new UserFacingException($"Offline data format version '{payload.FormatVersion}' is not supported.");
+        }
+
+        var entriesByKey = new Dictionary<string, DatabaseSchemaCacheEntry>(StringComparer.OrdinalIgnoreCase);
+        foreach (var entry in payload.Entries)
+        {
+            if (string.IsNullOrWhiteSpace(entry.ClusterUrl) || string.IsNullOrWhiteSpace(entry.DatabaseName))
+            {
+                throw new UserFacingException("The offline data import file contains an entry without clusterUrl or databaseName.");
+            }
+
+            var normalizedEntry = new DatabaseSchemaCacheEntry
+            {
+                CacheFormatVersion = 1,
+                ClusterUrl = ClusterUtilities.NormalizeClusterUrl(entry.ClusterUrl),
+                DatabaseName = entry.DatabaseName.Trim(),
+                CachedAtUtc = entry.CachedAtUtc == default ? DateTimeOffset.UtcNow : entry.CachedAtUtc,
+                SchemaVersion = entry.SchemaVersion,
+                SchemaJson = entry.SchemaJson ?? string.Empty,
+                TableNotes = NormalizeNotes(entry.TableNotes)
+            };
+
+            entriesByKey[$"{normalizedEntry.ClusterUrl}|{normalizedEntry.DatabaseName}"] = normalizedEntry;
+        }
+
+        foreach (var entry in entriesByKey.Values)
+        {
+            await _offlineTableDataStore.WriteEntryAsync(config, entry, cancellationToken);
+        }
+
+        return new CliOutput
+        {
+            Message = $"Imported {entriesByKey.Count.ToString(CultureInfo.InvariantCulture)} offline data entries from '{importPath}'."
+        };
+    }
+
+    public async Task<CliOutput> PurgeOfflineDataAsync(
+        KustoConfig config,
+        CancellationToken cancellationToken)
+    {
+        var entries = await _offlineTableDataStore.ReadAllEntriesAsync(config, cancellationToken);
+        if (entries.Count == 0)
+        {
+            return new CliOutput
+            {
+                Message = "No offline table data was found."
+            };
+        }
+
+        var changedDatabases = 0;
+        var removedTables = 0;
+        var removedNotes = 0;
+
+        foreach (var entry in entries)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var trackedTables = GetTrackedTableNames(entry);
+            if (trackedTables.Count == 0)
+            {
+                await _offlineTableDataStore.DeleteEntryAsync(config, entry.ClusterUrl, entry.DatabaseName, cancellationToken);
+                changedDatabases++;
+                continue;
+            }
+
+            var liveTables = await GetLiveTablesAsync(entry.ClusterUrl, entry.DatabaseName, cancellationToken);
+            var missingTables = trackedTables
+                .Where(table => !liveTables.Contains(table))
+                .ToList();
+
+            if (missingTables.Count == 0)
+            {
+                continue;
+            }
+
+            changedDatabases++;
+            removedTables += missingTables.Count;
+
+            foreach (var missingTable in missingTables)
+            {
+                if (entry.TableNotes.TryGetValue(missingTable, out var notes))
+                {
+                    removedNotes += notes.Count;
+                    entry.TableNotes.Remove(missingTable);
+                }
+
+                entry.SchemaJson = DatabaseSchemaJson.RemoveTable(entry.SchemaJson, entry.DatabaseName, missingTable);
+            }
+
+            await PersistOrDeleteAsync(config, entry, cancellationToken);
+        }
+
+        return new CliOutput
+        {
+            Message = removedTables == 0
+                ? "No stale offline table data was found."
+                : $"Purged offline data for {removedTables.ToString(CultureInfo.InvariantCulture)} tables across {changedDatabases.ToString(CultureInfo.InvariantCulture)} databases and removed {removedNotes.ToString(CultureInfo.InvariantCulture)} notes."
+        };
+    }
+
+    public async Task<CliOutput> ClearOfflineDataAsync(
+        KustoConfig config,
+        string? clusterUrl,
+        string? database,
+        string? tableName,
+        CancellationToken cancellationToken)
+    {
+        if (!string.IsNullOrWhiteSpace(tableName))
+        {
+            var normalizedClusterUrl = ClusterUtilities.NormalizeClusterUrl(clusterUrl!);
+            var entry = await _offlineTableDataStore.TryReadEntryAsync(config, normalizedClusterUrl, database!, cancellationToken);
+            if (entry is null)
+            {
+                return new CliOutput
+                {
+                    Message = $"No offline data found for table '{tableName}'."
+                };
+            }
+
+            var removedNoteCount = entry.TableNotes.TryGetValue(tableName, out var notes) ? notes.Count : 0;
+            var hadSchema = DatabaseSchemaJson.GetTableNames(entry.SchemaJson, entry.DatabaseName)
+                .Any(name => string.Equals(name, tableName, StringComparison.OrdinalIgnoreCase));
+
+            entry.TableNotes.Remove(tableName);
+            entry.SchemaJson = DatabaseSchemaJson.RemoveTable(entry.SchemaJson, entry.DatabaseName, tableName);
+
+            if (!hadSchema && removedNoteCount == 0)
+            {
+                return new CliOutput
+                {
+                    Message = $"No offline data found for table '{tableName}'."
+                };
+            }
+
+            await PersistOrDeleteAsync(config, entry, cancellationToken);
+            return new CliOutput
+            {
+                Message = $"Cleared offline data for table '{tableName}'."
+            };
+        }
+
+        var entries = await _offlineTableDataStore.ReadAllEntriesAsync(config, cancellationToken);
+        var removedDatabases = entries.Count;
+        var removedTables = entries.Sum(entry => GetTrackedTableNames(entry).Count);
+        var removedNotes = entries.Sum(entry => entry.TableNotes.Values.Sum(notes => notes.Count));
+
+        foreach (var entry in entries)
+        {
+            await _offlineTableDataStore.DeleteEntryAsync(config, entry.ClusterUrl, entry.DatabaseName, cancellationToken);
+        }
+
+        return new CliOutput
+        {
+            Message = removedDatabases == 0
+                ? "No offline table data was found."
+                : $"Cleared offline data for {removedTables.ToString(CultureInfo.InvariantCulture)} tables across {removedDatabases.ToString(CultureInfo.InvariantCulture)} databases and removed {removedNotes.ToString(CultureInfo.InvariantCulture)} notes."
+        };
+    }
+
+    private async Task<HashSet<string>> GetLiveTablesAsync(
+        string clusterUrl,
+        string database,
+        CancellationToken cancellationToken)
+    {
+        var result = await _kustoService.ExecuteManagementCommandAsync(
+            clusterUrl,
+            database,
+            ".show tables | project TableName",
+            null,
+            cancellationToken);
+
+        var liveTables = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var nameColumnIndex = result.TryGetColumnIndex("TableName", out var index) ? index : 0;
+        foreach (var row in result.Rows)
+        {
+            if (nameColumnIndex >= 0 &&
+                nameColumnIndex < row.Count &&
+                !string.IsNullOrWhiteSpace(row[nameColumnIndex]))
+            {
+                liveTables.Add(row[nameColumnIndex]!);
+            }
+        }
+
+        return liveTables;
+    }
+
+    private static DatabaseSchemaCacheEntry CreateEmptyEntry(string clusterUrl, string database)
+    {
+        return new DatabaseSchemaCacheEntry
+        {
+            CacheFormatVersion = 1,
+            ClusterUrl = clusterUrl,
+            DatabaseName = database,
+            CachedAtUtc = DateTimeOffset.UtcNow,
+            TableNotes = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase)
+        };
+    }
+
+    private async Task PersistOrDeleteAsync(
+        KustoConfig config,
+        DatabaseSchemaCacheEntry? entry,
+        CancellationToken cancellationToken)
+    {
+        if (entry is null)
+        {
+            return;
+        }
+
+        if (!HasAnyOfflineData(entry))
+        {
+            await _offlineTableDataStore.DeleteEntryAsync(config, entry.ClusterUrl, entry.DatabaseName, cancellationToken);
+            return;
+        }
+
+        await _offlineTableDataStore.WriteEntryAsync(config, entry, cancellationToken);
+    }
+
+    private static List<string> GetNotes(DatabaseSchemaCacheEntry? entry, string tableName)
+    {
+        if (entry?.TableNotes is null || !entry.TableNotes.TryGetValue(tableName, out var notes))
+        {
+            return [];
+        }
+
+        return notes;
+    }
+
+    private static TabularData BuildNotesTable(IEnumerable<(int Id, string Note)> notes)
+    {
+        var rows = new List<IReadOnlyList<string?>>();
+        foreach (var note in notes)
+        {
+            rows.Add([note.Id.ToString(CultureInfo.InvariantCulture), note.Note]);
+        }
+
+        return new TabularData(
+            ["Id", "Note"],
+            rows);
+    }
+
+    private static HashSet<string> GetTrackedTableNames(DatabaseSchemaCacheEntry entry)
+    {
+        var trackedTables = new HashSet<string>(
+            DatabaseSchemaJson.GetTableNames(entry.SchemaJson, entry.DatabaseName),
+            StringComparer.OrdinalIgnoreCase);
+
+        foreach (var tableName in entry.TableNotes.Keys)
+        {
+            trackedTables.Add(tableName);
+        }
+
+        return trackedTables;
+    }
+
+    private static bool HasAnyOfflineData(DatabaseSchemaCacheEntry entry)
+    {
+        return DatabaseSchemaJson.GetTableNames(entry.SchemaJson, entry.DatabaseName).Count > 0 ||
+               entry.TableNotes.Values.Any(notes => notes.Count > 0);
+    }
+
+    private static Dictionary<string, List<string>> NormalizeNotes(Dictionary<string, List<string>>? tableNotes)
+    {
+        var normalized = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
+        if (tableNotes is null)
+        {
+            return normalized;
+        }
+
+        foreach (var pair in tableNotes)
+        {
+            if (string.IsNullOrWhiteSpace(pair.Key))
+            {
+                continue;
+            }
+
+            var notes = pair.Value?
+                .Where(note => !string.IsNullOrWhiteSpace(note))
+                .Select(note => note.Trim())
+                .ToList();
+
+            if (notes is { Count: > 0 })
+            {
+                normalized[pair.Key.Trim()] = notes;
+            }
+        }
+
+        return normalized;
+    }
+
+    private void EnsurePositiveId(int value, string optionName)
+    {
+        if (value <= 0)
+        {
+            throw new UserFacingException($"The {optionName} value must be a positive integer.");
+        }
+    }
+}

--- a/src/Kusto.Cli/TableSchemaProvider.cs
+++ b/src/Kusto.Cli/TableSchemaProvider.cs
@@ -1,101 +1,138 @@
-using System.Security.Cryptography;
-using System.Text;
-using System.Text.Json;
 using Microsoft.Extensions.Logging;
 
 namespace Kusto.Cli;
 
 public sealed class TableSchemaProvider(
     IKustoService kustoService,
+    OfflineTableDataStore offlineTableDataStore,
     SchemaCacheSettingsResolver settingsResolver,
     ILogger<TableSchemaProvider> logger,
     TimeProvider? timeProvider = null) : ITableSchemaProvider
 {
-    private const int CacheFormatVersion = 1;
-
     private readonly IKustoService _kustoService = kustoService;
+    private readonly OfflineTableDataStore _offlineTableDataStore = offlineTableDataStore;
     private readonly SchemaCacheSettingsResolver _settingsResolver = settingsResolver;
     private readonly ILogger<TableSchemaProvider> _logger = logger;
     private readonly TimeProvider _timeProvider = timeProvider ?? TimeProvider.System;
 
-    public Task<Dictionary<string, string?>> GetTablePropertiesAsync(
+    public async Task<TableSchemaDetails> GetTableSchemaDetailsAsync(
         KustoConfig config,
         string clusterUrl,
         string database,
         string tableName,
-        CancellationToken cancellationToken)
-    {
-        var settings = _settingsResolver.Resolve(config, clusterUrl, database);
-        return settings.Enabled
-            ? GetCachedTablePropertiesAsync(settings, clusterUrl, database, tableName, cancellationToken)
-            : GetLiveTablePropertiesAsync(clusterUrl, database, tableName, cancellationToken);
-    }
-
-    private async Task<Dictionary<string, string?>> GetCachedTablePropertiesAsync(
-        ResolvedSchemaCacheSettings settings,
-        string clusterUrl,
-        string database,
-        string tableName,
+        bool refreshOfflineData,
         CancellationToken cancellationToken)
     {
         var normalizedClusterUrl = ClusterUtilities.NormalizeClusterUrl(clusterUrl);
-        var cachePath = BuildCachePath(settings.CacheDirectory, normalizedClusterUrl, database);
-        var cacheEntry = await TryReadCacheEntryAsync(cachePath, cancellationToken);
+        var settings = _settingsResolver.Resolve(config, normalizedClusterUrl, database);
+        var existingEntry = await _offlineTableDataStore.TryReadEntryAsync(config, normalizedClusterUrl, database, cancellationToken);
 
-        if (cacheEntry is not null && !IsExpired(cacheEntry, settings.Ttl))
+        DatabaseSchemaCacheEntry? schemaEntry = existingEntry;
+        string schemaJson;
+
+        if (refreshOfflineData)
         {
-            _logger.LogDebug("Using cached schema for {ClusterUrl}/{Database}.", normalizedClusterUrl, database);
-            try
+            schemaEntry = await FetchDatabaseSchemaEntryAsync(normalizedClusterUrl, database, existingEntry, cancellationToken);
+            await _offlineTableDataStore.WriteEntryAsync(config, schemaEntry, cancellationToken);
+            schemaJson = schemaEntry.SchemaJson;
+        }
+        else if (settings.Enabled)
+        {
+            if (HasSchema(existingEntry))
             {
-                return BuildPropertiesFromDatabaseSchema(cacheEntry.SchemaJson, database, tableName);
+                if (!IsExpired(existingEntry!, settings.Ttl))
+                {
+                    schemaJson = existingEntry!.SchemaJson;
+                }
+                else
+                {
+                    schemaEntry = await RefreshCacheEntryAsync(existingEntry!, normalizedClusterUrl, database, cancellationToken);
+                    await _offlineTableDataStore.WriteEntryAsync(config, schemaEntry, cancellationToken);
+                    schemaJson = schemaEntry.SchemaJson;
+                }
             }
-            catch (UserFacingException ex)
+            else
             {
-                _logger.LogDebug(ex, "Refreshing cached schema for {ClusterUrl}/{Database} after a cache lookup miss.", normalizedClusterUrl, database);
-                var refreshedEntry = await FetchDatabaseSchemaAsync(normalizedClusterUrl, database, cancellationToken);
-                await WriteCacheEntryAsync(cachePath, refreshedEntry, cancellationToken);
-                return BuildPropertiesFromDatabaseSchema(refreshedEntry.SchemaJson, database, tableName);
+                schemaEntry = await FetchDatabaseSchemaEntryAsync(normalizedClusterUrl, database, existingEntry, cancellationToken);
+                await _offlineTableDataStore.WriteEntryAsync(config, schemaEntry, cancellationToken);
+                schemaJson = schemaEntry.SchemaJson;
             }
         }
-
-        if (cacheEntry is not null)
+        else
         {
-            cacheEntry = await RefreshCacheEntryAsync(cacheEntry, normalizedClusterUrl, database, cachePath, cancellationToken);
-            return BuildPropertiesFromDatabaseSchema(cacheEntry.SchemaJson, database, tableName);
+            schemaJson = await FetchDatabaseSchemaJsonAsync(normalizedClusterUrl, database, cancellationToken);
         }
 
-        var fetchedEntry = await FetchDatabaseSchemaAsync(normalizedClusterUrl, database, cancellationToken);
-        await WriteCacheEntryAsync(cachePath, fetchedEntry, cancellationToken);
-        return BuildPropertiesFromDatabaseSchema(fetchedEntry.SchemaJson, database, tableName);
+        try
+        {
+            return DatabaseSchemaJson.BuildTableSchemaDetails(schemaJson, database, tableName, GetTableNotes(schemaEntry ?? existingEntry, tableName));
+        }
+        catch (UserFacingException ex) when (!refreshOfflineData && settings.Enabled && HasSchema(existingEntry))
+        {
+            _logger.LogDebug(ex, "Refreshing cached schema for {ClusterUrl}/{Database} after a cache lookup miss.", normalizedClusterUrl, database);
+            schemaEntry = await FetchDatabaseSchemaEntryAsync(normalizedClusterUrl, database, existingEntry, cancellationToken);
+            await _offlineTableDataStore.WriteEntryAsync(config, schemaEntry, cancellationToken);
+            return DatabaseSchemaJson.BuildTableSchemaDetails(schemaEntry.SchemaJson, database, tableName, GetTableNotes(schemaEntry, tableName));
+        }
     }
 
     private async Task<DatabaseSchemaCacheEntry> RefreshCacheEntryAsync(
         DatabaseSchemaCacheEntry cacheEntry,
         string clusterUrl,
         string database,
-        string cachePath,
         CancellationToken cancellationToken)
     {
         if (!string.IsNullOrWhiteSpace(cacheEntry.SchemaVersion))
         {
-            var refreshedEntry = await TryFetchDatabaseSchemaIfUpdatedAsync(clusterUrl, database, cacheEntry.SchemaVersion, cancellationToken);
+            var refreshedEntry = await TryFetchDatabaseSchemaIfUpdatedAsync(clusterUrl, database, cacheEntry, cancellationToken);
             if (refreshedEntry is null)
             {
                 cacheEntry.CachedAtUtc = _timeProvider.GetUtcNow();
-                await WriteCacheEntryAsync(cachePath, cacheEntry, cancellationToken);
                 return cacheEntry;
             }
 
-            await WriteCacheEntryAsync(cachePath, refreshedEntry, cancellationToken);
             return refreshedEntry;
         }
 
-        var fullRefresh = await FetchDatabaseSchemaAsync(clusterUrl, database, cancellationToken);
-        await WriteCacheEntryAsync(cachePath, fullRefresh, cancellationToken);
-        return fullRefresh;
+        return await FetchDatabaseSchemaEntryAsync(clusterUrl, database, cacheEntry, cancellationToken);
     }
 
-    private async Task<DatabaseSchemaCacheEntry> FetchDatabaseSchemaAsync(
+    private async Task<DatabaseSchemaCacheEntry> FetchDatabaseSchemaEntryAsync(
+        string clusterUrl,
+        string database,
+        DatabaseSchemaCacheEntry? existingEntry,
+        CancellationToken cancellationToken)
+    {
+        var schemaJson = await FetchDatabaseSchemaJsonAsync(clusterUrl, database, cancellationToken);
+        return CreateCacheEntry(clusterUrl, database, schemaJson, existingEntry?.TableNotes);
+    }
+
+    private async Task<DatabaseSchemaCacheEntry?> TryFetchDatabaseSchemaIfUpdatedAsync(
+        string clusterUrl,
+        string database,
+        DatabaseSchemaCacheEntry existingEntry,
+        CancellationToken cancellationToken)
+    {
+        var result = await _kustoService.ExecuteManagementCommandAsync(
+            clusterUrl,
+            database,
+            BuildShowDatabaseSchemaCommand(database, existingEntry.SchemaVersion),
+            null,
+            cancellationToken);
+
+        if (result.Rows.Count == 0)
+        {
+            return null;
+        }
+
+        return CreateCacheEntry(
+            clusterUrl,
+            database,
+            DatabaseSchemaJson.ExtractSchemaJson(result),
+            existingEntry.TableNotes);
+    }
+
+    private async Task<string> FetchDatabaseSchemaJsonAsync(
         string clusterUrl,
         string database,
         CancellationToken cancellationToken)
@@ -107,135 +144,24 @@ public sealed class TableSchemaProvider(
             null,
             cancellationToken);
 
-        return CreateCacheEntry(clusterUrl, database, ExtractSchemaJson(result));
+        return DatabaseSchemaJson.ExtractSchemaJson(result);
     }
 
-    private async Task<DatabaseSchemaCacheEntry?> TryFetchDatabaseSchemaIfUpdatedAsync(
+    private DatabaseSchemaCacheEntry CreateCacheEntry(
         string clusterUrl,
         string database,
-        string schemaVersion,
-        CancellationToken cancellationToken)
-    {
-        var result = await _kustoService.ExecuteManagementCommandAsync(
-            clusterUrl,
-            database,
-            BuildShowDatabaseSchemaCommand(database, schemaVersion),
-            null,
-            cancellationToken);
-
-        if (result.Rows.Count == 0)
-        {
-            return null;
-        }
-
-        return CreateCacheEntry(clusterUrl, database, ExtractSchemaJson(result));
-    }
-
-    private async Task<Dictionary<string, string?>> GetLiveTablePropertiesAsync(
-        string clusterUrl,
-        string database,
-        string tableName,
-        CancellationToken cancellationToken)
-    {
-        var command = $".show table ['{KustoCommandText.EscapeSingleQuotedLiteral(tableName)}'] schema as json";
-        var result = await _kustoService.ExecuteManagementCommandAsync(
-            clusterUrl,
-            database,
-            command,
-            null,
-            cancellationToken);
-
-        if (result.Rows.Count == 0)
-        {
-            throw new UserFacingException($"Table '{tableName}' was not found.");
-        }
-
-        return ConvertRowToProperties(result, 0);
-    }
-
-    private async Task<DatabaseSchemaCacheEntry?> TryReadCacheEntryAsync(string cachePath, CancellationToken cancellationToken)
-    {
-        if (!File.Exists(cachePath))
-        {
-            return null;
-        }
-
-        try
-        {
-            await using var stream = File.OpenRead(cachePath);
-            var cacheEntry = await JsonSerializer.DeserializeAsync(
-                stream,
-                KustoJsonSerializerContext.Default.DatabaseSchemaCacheEntry,
-                cancellationToken);
-
-            if (cacheEntry is null || cacheEntry.CacheFormatVersion != CacheFormatVersion)
-            {
-                return null;
-            }
-
-            return cacheEntry;
-        }
-        catch (Exception ex) when (ex is JsonException or IOException or UnauthorizedAccessException)
-        {
-            _logger.LogWarning(ex, "Ignoring unreadable schema cache entry at {CachePath}.", cachePath);
-            return null;
-        }
-    }
-
-    private async Task WriteCacheEntryAsync(string cachePath, DatabaseSchemaCacheEntry cacheEntry, CancellationToken cancellationToken)
-    {
-        var cacheDirectory = Path.GetDirectoryName(cachePath);
-        if (string.IsNullOrWhiteSpace(cacheDirectory))
-        {
-            return;
-        }
-
-        var temporaryPath = Path.Combine(cacheDirectory, $"{Path.GetFileName(cachePath)}.{Guid.NewGuid():N}.tmp");
-
-        try
-        {
-            Directory.CreateDirectory(cacheDirectory);
-            await using (var stream = File.Create(temporaryPath))
-            {
-                await JsonSerializer.SerializeAsync(
-                    stream,
-                    cacheEntry,
-                    KustoJsonSerializerContext.Default.DatabaseSchemaCacheEntry,
-                    cancellationToken);
-            }
-
-            File.Move(temporaryPath, cachePath, true);
-        }
-        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
-        {
-            _logger.LogWarning(ex, "Failed to write schema cache entry to {CachePath}.", cachePath);
-        }
-        finally
-        {
-            try
-            {
-                if (File.Exists(temporaryPath))
-                {
-                    File.Delete(temporaryPath);
-                }
-            }
-            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
-            {
-                _logger.LogDebug(ex, "Failed to clean up temporary schema cache file {TemporaryPath}.", temporaryPath);
-            }
-        }
-    }
-
-    private DatabaseSchemaCacheEntry CreateCacheEntry(string clusterUrl, string database, string schemaJson)
+        string schemaJson,
+        Dictionary<string, List<string>>? tableNotes)
     {
         return new DatabaseSchemaCacheEntry
         {
-            CacheFormatVersion = CacheFormatVersion,
+            CacheFormatVersion = 1,
             ClusterUrl = clusterUrl,
             DatabaseName = database,
             CachedAtUtc = _timeProvider.GetUtcNow(),
-            SchemaVersion = ExtractDatabaseSchemaVersion(schemaJson, database),
-            SchemaJson = schemaJson
+            SchemaVersion = DatabaseSchemaJson.ExtractDatabaseSchemaVersion(schemaJson, database),
+            SchemaJson = schemaJson,
+            TableNotes = CloneNotes(tableNotes)
         };
     }
 
@@ -251,11 +177,14 @@ public sealed class TableSchemaProvider(
         return $".show database ['{escapedDatabase}'] schema if_later_than \"{escapedSchemaVersion}\" as json";
     }
 
-    private static string BuildCachePath(string cacheDirectory, string clusterUrl, string database)
+    private IReadOnlyList<string>? GetTableNotes(DatabaseSchemaCacheEntry? cacheEntry, string tableName)
     {
-        var keyBytes = Encoding.UTF8.GetBytes($"database-schema:v{CacheFormatVersion}:{clusterUrl.ToLowerInvariant()}|{database.ToLowerInvariant()}");
-        var hash = Convert.ToHexString(SHA256.HashData(keyBytes)).ToLowerInvariant();
-        return Path.Combine(cacheDirectory, $"{hash}.json");
+        if (cacheEntry?.TableNotes is null || !cacheEntry.TableNotes.TryGetValue(tableName, out var notes) || notes.Count == 0)
+        {
+            return null;
+        }
+
+        return notes;
     }
 
     private bool IsExpired(DatabaseSchemaCacheEntry cacheEntry, TimeSpan ttl)
@@ -263,208 +192,37 @@ public sealed class TableSchemaProvider(
         return _timeProvider.GetUtcNow() - cacheEntry.CachedAtUtc >= ttl;
     }
 
-    private static string ExtractSchemaJson(TabularData result)
+    private bool HasSchema(DatabaseSchemaCacheEntry? cacheEntry)
     {
-        if (result.Rows.Count == 0)
-        {
-            throw new UserFacingException("Kusto did not return a database schema.");
-        }
-
-        var row = result.Rows[0];
-        if (TryGetPreferredValue(result, row, "DatabaseSchema", out var preferredValue) ||
-            TryGetPreferredValue(result, row, "Schema", out preferredValue))
-        {
-            return preferredValue!;
-        }
-
-        for (var i = 0; i < row.Count; i++)
-        {
-            if (!string.IsNullOrWhiteSpace(row[i]))
-            {
-                return row[i]!;
-            }
-        }
-
-        throw new UserFacingException("Kusto returned an empty database schema payload.");
-    }
-
-    private static Dictionary<string, string?> BuildPropertiesFromDatabaseSchema(string schemaJson, string database, string tableName)
-    {
-        try
-        {
-            using var document = JsonDocument.Parse(schemaJson);
-            var databaseElement = FindDatabaseElement(document.RootElement, database);
-            if (!TryGetNamedProperty(databaseElement, "Tables", out var tablesElement) ||
-                tablesElement.ValueKind != JsonValueKind.Object ||
-                !TryGetNamedProperty(tablesElement, tableName, out var tableElement) ||
-                tableElement.ValueKind != JsonValueKind.Object)
-            {
-                throw new UserFacingException($"Table '{tableName}' was not found.");
-            }
-
-            if (!TryGetNamedProperty(tableElement, "OrderedColumns", out var orderedColumnsElement) ||
-                orderedColumnsElement.ValueKind != JsonValueKind.Array)
-            {
-                throw new UserFacingException($"Kusto returned a schema for table '{tableName}' without OrderedColumns.");
-            }
-
-            var properties = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase)
-            {
-                ["TableName"] = GetStringProperty(tableElement, "Name") ?? tableName,
-                ["Schema"] = orderedColumnsElement.GetRawText(),
-                ["DatabaseName"] = GetStringProperty(databaseElement, "Name") ?? database
-            };
-
-            AddOptionalProperty(properties, tableElement, "Folder");
-            AddOptionalProperty(properties, tableElement, "DocString");
-
-            return properties;
-        }
-        catch (UserFacingException)
-        {
-            throw;
-        }
-        catch (JsonException ex)
-        {
-            throw new UserFacingException("Kusto returned an unexpected database schema format.", ex);
-        }
-    }
-
-    private static string? ExtractDatabaseSchemaVersion(string schemaJson, string database)
-    {
-        try
-        {
-            using var document = JsonDocument.Parse(schemaJson);
-            var databaseElement = FindDatabaseElement(document.RootElement, database);
-
-            var explicitVersion = GetStringProperty(databaseElement, "Version");
-            if (!string.IsNullOrWhiteSpace(explicitVersion))
-            {
-                return explicitVersion;
-            }
-
-            if (TryGetNamedProperty(databaseElement, "MajorVersion", out var majorVersionElement) &&
-                TryGetNamedProperty(databaseElement, "MinorVersion", out var minorVersionElement) &&
-                TryGetInt32(majorVersionElement, out var majorVersion) &&
-                TryGetInt32(minorVersionElement, out var minorVersion))
-            {
-                return $"v{majorVersion}.{minorVersion}";
-            }
-
-            return null;
-        }
-        catch (JsonException ex)
-        {
-            throw new UserFacingException("Kusto returned an unexpected database schema format.", ex);
-        }
-    }
-
-    private static JsonElement FindDatabaseElement(JsonElement rootElement, string database)
-    {
-        if (TryGetNamedProperty(rootElement, "Databases", out var databasesElement) &&
-            databasesElement.ValueKind == JsonValueKind.Object)
-        {
-            if (TryGetNamedProperty(databasesElement, database, out var databaseElement))
-            {
-                return databaseElement;
-            }
-
-            if (databasesElement.EnumerateObject().FirstOrDefault() is { Name: not null } firstDatabase)
-            {
-                return firstDatabase.Value;
-            }
-        }
-
-        if (TryGetNamedProperty(rootElement, "Tables", out _))
-        {
-            return rootElement;
-        }
-
-        throw new UserFacingException($"Kusto did not return a schema for database '{database}'.");
-    }
-
-    private static bool TryGetNamedProperty(JsonElement element, string propertyName, out JsonElement value)
-    {
-        if (element.ValueKind != JsonValueKind.Object)
-        {
-            value = default;
-            return false;
-        }
-
-        if (element.TryGetProperty(propertyName, out value))
-        {
-            return true;
-        }
-
-        foreach (var property in element.EnumerateObject())
-        {
-            if (string.Equals(property.Name, propertyName, StringComparison.OrdinalIgnoreCase))
-            {
-                value = property.Value;
-                return true;
-            }
-        }
-
-        value = default;
-        return false;
-    }
-
-    private static string? GetStringProperty(JsonElement element, string propertyName)
-    {
-        return TryGetNamedProperty(element, propertyName, out var value) && value.ValueKind == JsonValueKind.String
-            ? value.GetString()
-            : null;
-    }
-
-    private static bool TryGetInt32(JsonElement element, out int value)
-    {
-        value = 0;
-        return element.ValueKind switch
-        {
-            JsonValueKind.Number => element.TryGetInt32(out value),
-            JsonValueKind.String => int.TryParse(element.GetString(), out value),
-            _ => false
-        };
-    }
-
-    private static void AddOptionalProperty(Dictionary<string, string?> properties, JsonElement element, string propertyName)
-    {
-        var value = GetStringProperty(element, propertyName);
-        if (!string.IsNullOrWhiteSpace(value))
-        {
-            properties[propertyName] = value;
-        }
-    }
-
-    private static Dictionary<string, string?> ConvertRowToProperties(TabularData table, int rowIndex)
-    {
-        var properties = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
-        if (rowIndex >= table.Rows.Count)
-        {
-            return properties;
-        }
-
-        var row = table.Rows[rowIndex];
-        for (var i = 0; i < table.Columns.Count; i++)
-        {
-            var value = i < row.Count ? row[i] : null;
-            properties[table.Columns[i]] = value;
-        }
-
-        return properties;
-    }
-
-    private static bool TryGetPreferredValue(TabularData table, IReadOnlyList<string?> row, string columnName, out string? value)
-    {
-        value = null;
-        if (!table.TryGetColumnIndex(columnName, out var columnIndex) ||
-            columnIndex >= row.Count ||
-            string.IsNullOrWhiteSpace(row[columnIndex]))
+        if (cacheEntry is null || string.IsNullOrWhiteSpace(cacheEntry.SchemaJson))
         {
             return false;
         }
 
-        value = row[columnIndex];
-        return true;
+        try
+        {
+            return DatabaseSchemaJson.GetTableNames(cacheEntry.SchemaJson, cacheEntry.DatabaseName).Count > 0;
+        }
+        catch (UserFacingException ex)
+        {
+            _logger.LogDebug(ex, "Ignoring unreadable cached schema for {ClusterUrl}/{Database}.", cacheEntry.ClusterUrl, cacheEntry.DatabaseName);
+            return false;
+        }
+    }
+
+    private static Dictionary<string, List<string>> CloneNotes(Dictionary<string, List<string>>? tableNotes)
+    {
+        var clone = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
+        if (tableNotes is null)
+        {
+            return clone;
+        }
+
+        foreach (var pair in tableNotes)
+        {
+            clone[pair.Key] = [.. pair.Value];
+        }
+
+        return clone;
     }
 }

--- a/tests/Kusto.Cli.Tests/ConfirmationPromptTests.cs
+++ b/tests/Kusto.Cli.Tests/ConfirmationPromptTests.cs
@@ -1,0 +1,40 @@
+namespace Kusto.Cli.Tests;
+
+[Collection("Console")]
+public sealed class ConfirmationPromptTests
+{
+    [Fact]
+    public async Task ConfirmAsync_WritesPromptToProvidedWriter()
+    {
+        using var input = new StringReader("y" + Environment.NewLine);
+        using var output = new StringWriter();
+        var prompt = new ConsoleConfirmationPrompt(input, output);
+
+        var confirmed = await prompt.ConfirmAsync("Clear offline table data?", CancellationToken.None);
+
+        Assert.True(confirmed);
+        Assert.Contains("Clear offline table data? [y/N]", output.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task CreateRuntime_UsesConfiguredStderrWriterForConfirmationPrompts()
+    {
+        var originalInput = Console.In;
+        using var stderr = new StringWriter();
+
+        try
+        {
+            Console.SetIn(new StringReader("n" + Environment.NewLine));
+            using var runtime = CliRunner.CreateRuntime(null, stderrWriter: stderr);
+
+            var confirmed = await runtime.ConfirmationPrompt.ConfirmAsync("Clear all notes?", CancellationToken.None);
+
+            Assert.False(confirmed);
+            Assert.Contains("Clear all notes? [y/N]", stderr.ToString(), StringComparison.Ordinal);
+        }
+        finally
+        {
+            Console.SetIn(originalInput);
+        }
+    }
+}

--- a/tests/Kusto.Cli.Tests/ParserTests.cs
+++ b/tests/Kusto.Cli.Tests/ParserTests.cs
@@ -87,6 +87,36 @@ public sealed class ParserTests
     }
 
     [Fact]
+    public void Parse_TableShow_AcceptsRefreshOfflineData()
+    {
+        var rootCommand = CommandFactory.CreateRootCommand();
+        var result = rootCommand.Parse(["table", "show", "StormEvents", "--refresh-offline-data"], new ParserConfiguration());
+        Assert.Empty(result.Errors);
+    }
+
+    [Fact]
+    public void Parse_TableNotesCommands_AreAccepted()
+    {
+        var rootCommand = CommandFactory.CreateRootCommand();
+
+        Assert.Empty(rootCommand.Parse(["table", "notes", "StormEvents", "--add", "Useful note", "--cluster", "help", "--db", "Samples"], new ParserConfiguration()).Errors);
+        Assert.Empty(rootCommand.Parse(["table", "notes", "StormEvents", "--id", "1", "--cluster", "help", "--db", "Samples"], new ParserConfiguration()).Errors);
+        Assert.Empty(rootCommand.Parse(["table", "notes", "StormEvents", "--delete", "1", "--cluster", "help", "--db", "Samples"], new ParserConfiguration()).Errors);
+        Assert.Empty(rootCommand.Parse(["table", "notes", "--clear", "--force"], new ParserConfiguration()).Errors);
+    }
+
+    [Fact]
+    public void Parse_TableOfflineDataCommands_AreAccepted()
+    {
+        var rootCommand = CommandFactory.CreateRootCommand();
+
+        Assert.Empty(rootCommand.Parse(["table", "--export-offline-data", "offline-data.json"], new ParserConfiguration()).Errors);
+        Assert.Empty(rootCommand.Parse(["table", "--import-offline-data", "offline-data.json"], new ParserConfiguration()).Errors);
+        Assert.Empty(rootCommand.Parse(["table", "--purge-offline-data", "--force"], new ParserConfiguration()).Errors);
+        Assert.Empty(rootCommand.Parse(["table", "StormEvents", "--clear-offline-data", "--cluster", "help", "--db", "Samples", "--force"], new ParserConfiguration()).Errors);
+    }
+
+    [Fact]
     public void Parse_QueryAliases_AcceptRunAndFileAlias()
     {
         var rootCommand = CommandFactory.CreateRootCommand();

--- a/tests/Kusto.Cli.Tests/TableOfflineDataManagerTests.cs
+++ b/tests/Kusto.Cli.Tests/TableOfflineDataManagerTests.cs
@@ -1,0 +1,295 @@
+using System.Security.Cryptography;
+using System.Text;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Kusto.Cli.Tests;
+
+public sealed class TableOfflineDataManagerTests
+{
+    [Fact]
+    public async Task AddTableNoteAsync_ThenShowTableNotesAsync_ReturnsSequentialIds()
+    {
+        var cacheDirectory = CreateTemporaryDirectory();
+
+        try
+        {
+            var manager = CreateManager(_ => throw new InvalidOperationException("Unexpected command."), cacheDirectory);
+            var config = CreateConfig(cacheDirectory);
+
+            _ = await manager.AddTableNoteAsync(config, "https://help.kusto.windows.net", "Samples", "StormEvents", "First note", CancellationToken.None);
+            _ = await manager.AddTableNoteAsync(config, "https://help.kusto.windows.net", "Samples", "StormEvents", "Second note", CancellationToken.None);
+
+            var output = await manager.ShowTableNotesAsync(config, "https://help.kusto.windows.net", "Samples", "StormEvents", null, CancellationToken.None);
+
+            Assert.NotNull(output.Table);
+            Assert.Equal(["Id", "Note"], output.Table.Columns);
+            Assert.Equal(2, output.Table.Rows.Count);
+            Assert.Equal("1", output.Table.Rows[0][0]);
+            Assert.Equal("First note", output.Table.Rows[0][1]);
+            Assert.Equal("2", output.Table.Rows[1][0]);
+            Assert.Equal("Second note", output.Table.Rows[1][1]);
+        }
+        finally
+        {
+            DeleteDirectory(cacheDirectory);
+        }
+    }
+
+    [Fact]
+    public async Task ClearOfflineDataAsync_WhenSpecificTableCleared_RemovesEntry()
+    {
+        const string clusterUrl = "https://help.kusto.windows.net";
+        const string database = "Samples";
+        var cacheDirectory = CreateTemporaryDirectory();
+
+        try
+        {
+            var store = CreateStore();
+            var config = CreateConfig(cacheDirectory);
+            await store.WriteEntryAsync(
+                config,
+                new DatabaseSchemaCacheEntry
+                {
+                    CacheFormatVersion = 1,
+                    ClusterUrl = clusterUrl,
+                    DatabaseName = database,
+                    CachedAtUtc = DateTimeOffset.UtcNow,
+                    SchemaVersion = "v1.1",
+                    SchemaJson = CreateDatabaseSchemaJson(database, "StormEvents"),
+                    TableNotes = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase)
+                    {
+                        ["StormEvents"] = ["Remember this table"]
+                    }
+                },
+                CancellationToken.None);
+
+            var manager = CreateManager(_ => throw new InvalidOperationException("Unexpected command."), cacheDirectory);
+            var output = await manager.ClearOfflineDataAsync(config, clusterUrl, database, "StormEvents", CancellationToken.None);
+            var entry = await store.TryReadEntryAsync(config, clusterUrl, database, CancellationToken.None);
+
+            Assert.Equal("Cleared offline data for table 'StormEvents'.", output.Message);
+            Assert.Null(entry);
+        }
+        finally
+        {
+            DeleteDirectory(cacheDirectory);
+        }
+    }
+
+    [Fact]
+    public async Task ExportOfflineDataAsync_AndImportOfflineDataAsync_RoundTripsEntries()
+    {
+        var sourceCacheDirectory = CreateTemporaryDirectory();
+        var targetCacheDirectory = CreateTemporaryDirectory();
+        var exportPath = Path.Combine(Path.GetTempPath(), $"kusto-offline-data-{Guid.NewGuid():N}.json");
+
+        try
+        {
+            var store = CreateStore();
+            var sourceConfig = CreateConfig(sourceCacheDirectory);
+            await store.WriteEntryAsync(
+                sourceConfig,
+                new DatabaseSchemaCacheEntry
+                {
+                    CacheFormatVersion = 1,
+                    ClusterUrl = "https://help.kusto.windows.net",
+                    DatabaseName = "Samples",
+                    CachedAtUtc = DateTimeOffset.UtcNow,
+                    SchemaVersion = "v1.1",
+                    SchemaJson = CreateDatabaseSchemaJson("Samples", "StormEvents"),
+                    TableNotes = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase)
+                    {
+                        ["StormEvents"] = ["Exported note"]
+                    }
+                },
+                CancellationToken.None);
+
+            var sourceManager = CreateManager(_ => throw new InvalidOperationException("Unexpected command."), sourceCacheDirectory);
+            var exportOutput = await sourceManager.ExportOfflineDataAsync(sourceConfig, exportPath, CancellationToken.None);
+
+            var targetConfig = CreateConfig(targetCacheDirectory);
+            var targetManager = CreateManager(_ => throw new InvalidOperationException("Unexpected command."), targetCacheDirectory);
+            var importOutput = await targetManager.ImportOfflineDataAsync(targetConfig, exportPath, CancellationToken.None);
+            var importedEntry = await CreateStore().TryReadEntryAsync(targetConfig, "https://help.kusto.windows.net", "Samples", CancellationToken.None);
+
+            Assert.Contains("Exported 1 offline data entries", exportOutput.Message, StringComparison.Ordinal);
+            Assert.Contains("Imported 1 offline data entries", importOutput.Message, StringComparison.Ordinal);
+            Assert.NotNull(importedEntry);
+            Assert.Equal("v1.1", importedEntry.SchemaVersion);
+            Assert.Equal("Exported note", importedEntry.TableNotes["StormEvents"][0]);
+        }
+        finally
+        {
+            DeleteDirectory(sourceCacheDirectory);
+            DeleteDirectory(targetCacheDirectory);
+            if (File.Exists(exportPath))
+            {
+                File.Delete(exportPath);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task PurgeOfflineDataAsync_RemovesMissingTablesAndAssociatedNotes()
+    {
+        const string clusterUrl = "https://help.kusto.windows.net";
+        const string database = "Samples";
+        var cacheDirectory = CreateTemporaryDirectory();
+
+        try
+        {
+            var store = CreateStore();
+            var config = CreateConfig(cacheDirectory);
+            await store.WriteEntryAsync(
+                config,
+                new DatabaseSchemaCacheEntry
+                {
+                    CacheFormatVersion = 1,
+                    ClusterUrl = clusterUrl,
+                    DatabaseName = database,
+                    CachedAtUtc = DateTimeOffset.UtcNow,
+                    SchemaVersion = "v1.1",
+                    SchemaJson = CreateMultiTableSchemaJson(database),
+                    TableNotes = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase)
+                    {
+                        ["StormEvents"] = ["Remove me"],
+                        ["OtherTable"] = ["Keep me"]
+                    }
+                },
+                CancellationToken.None);
+
+            var manager = CreateManager(
+                command =>
+                {
+                    Assert.Equal(".show tables | project TableName", command);
+                    return new TabularData(["TableName"], [["OtherTable"]]);
+                },
+                cacheDirectory);
+
+            var output = await manager.PurgeOfflineDataAsync(config, CancellationToken.None);
+            var entry = await store.TryReadEntryAsync(config, clusterUrl, database, CancellationToken.None);
+
+            Assert.Contains("Purged offline data for 1 tables", output.Message, StringComparison.Ordinal);
+            Assert.NotNull(entry);
+            Assert.DoesNotContain("StormEvents", DatabaseSchemaJson.GetTableNames(entry.SchemaJson, database), StringComparer.OrdinalIgnoreCase);
+            Assert.False(entry.TableNotes.ContainsKey("StormEvents"));
+            Assert.True(entry.TableNotes.ContainsKey("OtherTable"));
+        }
+        finally
+        {
+            DeleteDirectory(cacheDirectory);
+        }
+    }
+
+    private static TableOfflineDataManager CreateManager(Func<string, TabularData> managementCommandHandler, string cacheDirectory)
+    {
+        return new TableOfflineDataManager(
+            new RecordingKustoService(managementCommandHandler),
+            CreateStore(),
+            NullLogger<TableOfflineDataManager>.Instance);
+    }
+
+    private static OfflineTableDataStore CreateStore()
+    {
+        var resolver = new SchemaCacheSettingsResolver();
+        return new OfflineTableDataStore(resolver, NullLogger<OfflineTableDataStore>.Instance);
+    }
+
+    private static KustoConfig CreateConfig(string cacheDirectory)
+    {
+        return new KustoConfig
+        {
+            SchemaCache = new SchemaCacheConfig
+            {
+                Enabled = true,
+                Path = cacheDirectory
+            }
+        };
+    }
+
+    private static string CreateDatabaseSchemaJson(string database, string tableName)
+    {
+        return $$"""
+            {
+              "Databases": {
+                "{{database}}": {
+                  "Name": "{{database}}",
+                  "Tables": {
+                    "{{tableName}}": {
+                      "Name": "{{tableName}}",
+                      "OrderedColumns": [{"Name":"State","Type":"System.String"}]
+                    }
+                  },
+                  "MajorVersion": 1,
+                  "MinorVersion": 1
+                }
+              }
+            }
+            """;
+    }
+
+    private static string CreateMultiTableSchemaJson(string database)
+    {
+        return $$"""
+            {
+              "Databases": {
+                "{{database}}": {
+                  "Name": "{{database}}",
+                  "Tables": {
+                    "StormEvents": {
+                      "Name": "StormEvents",
+                      "OrderedColumns": [{"Name":"State","Type":"System.String"}]
+                    },
+                    "OtherTable": {
+                      "Name": "OtherTable",
+                      "OrderedColumns": [{"Name":"Value","Type":"System.String"}]
+                    }
+                  },
+                  "MajorVersion": 1,
+                  "MinorVersion": 1
+                }
+              }
+            }
+            """;
+    }
+
+    private static string CreateTemporaryDirectory()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"kusto-offline-data-tests-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(path);
+        return path;
+    }
+
+    private static void DeleteDirectory(string path)
+    {
+        if (Directory.Exists(path))
+        {
+            Directory.Delete(path, recursive: true);
+        }
+    }
+
+    private sealed class RecordingKustoService(Func<string, TabularData> managementCommandHandler) : IKustoService
+    {
+        private readonly Func<string, TabularData> _managementCommandHandler = managementCommandHandler;
+
+        public Task<TabularData> ExecuteManagementCommandAsync(
+            string clusterUrl,
+            string? database,
+            string command,
+            IReadOnlyDictionary<string, string>? queryParameters,
+            CancellationToken cancellationToken)
+        {
+            return Task.FromResult(_managementCommandHandler(command));
+        }
+
+        public Task<QueryExecutionResult> ExecuteQueryAsync(
+            string clusterUrl,
+            string database,
+            string query,
+            bool includeStatistics,
+            CancellationToken cancellationToken)
+        {
+            throw new NotSupportedException();
+        }
+    }
+}

--- a/tests/Kusto.Cli.Tests/TableSchemaProviderTests.cs
+++ b/tests/Kusto.Cli.Tests/TableSchemaProviderTests.cs
@@ -7,20 +7,22 @@ namespace Kusto.Cli.Tests;
 public sealed class TableSchemaProviderTests
 {
     [Fact]
-    public async Task GetTablePropertiesAsync_WhenCacheDisabled_UsesLiveTableCommand()
+    public async Task GetTableSchemaDetailsAsync_WhenCacheDisabled_UsesLiveDatabaseSchemaCommand()
     {
         var service = new RecordingKustoService((_, _, command) =>
         {
-            Assert.Equal(".show table ['StormEvents'] schema as json", command);
-            return CreateTableSchemaResult("Samples", "StormEvents", """[{"Name":"State","Type":"System.String"}]""");
+            Assert.Equal(".show database ['Samples'] schema as json", command);
+            return CreateDatabaseSchemaResult(CreateDatabaseSchemaJson(
+                "Samples",
+                "StormEvents",
+                1,
+                1,
+                "Table level docstring",
+                ("State", "System.String", "State docstring")));
         });
-        var provider = new TableSchemaProvider(
-            service,
-            new SchemaCacheSettingsResolver(),
-            NullLogger<TableSchemaProvider>.Instance,
-            new FakeTimeProvider(DateTimeOffset.Parse("2026-03-06T00:00:00Z")));
+        var provider = CreateProvider(service, CreateTemporaryDirectory(), ttlSeconds: 300);
 
-        var properties = await provider.GetTablePropertiesAsync(
+        var details = await provider.GetTableSchemaDetailsAsync(
             new KustoConfig
             {
                 SchemaCache = new SchemaCacheConfig
@@ -31,22 +33,27 @@ public sealed class TableSchemaProviderTests
             "https://help.kusto.windows.net",
             "Samples",
             "StormEvents",
+            refreshOfflineData: false,
             CancellationToken.None);
 
-        Assert.Equal("StormEvents", properties["TableName"]);
-        Assert.Equal("""[{"Name":"State","Type":"System.String"}]""", properties["Schema"]);
+        Assert.Equal("StormEvents", details.Properties["TableName"]);
+        Assert.Equal("Table level docstring", details.Properties["DocString"]);
+        Assert.Equal("1", details.Properties["ColumnCount"]);
+        var row = Assert.Single(details.Columns.Rows);
+        Assert.Equal("State docstring", row[3]);
         Assert.Single(service.ManagementCommands);
     }
 
     [Fact]
-    public async Task GetTablePropertiesAsync_WhenCacheEnabled_UsesFreshCacheOnSecondRead()
+    public async Task GetTableSchemaDetailsAsync_WhenCacheEnabled_UsesFreshCacheOnSecondRead()
     {
         var service = new RecordingKustoService((_, _, _) => CreateDatabaseSchemaResult(CreateDatabaseSchemaJson(
             "Samples",
             "StormEvents",
             1,
             1,
-            ("State", "System.String"))));
+            null,
+            ("State", "System.String", null))));
         var cacheDirectory = CreateTemporaryDirectory();
 
         try
@@ -54,21 +61,23 @@ public sealed class TableSchemaProviderTests
             var provider = CreateProvider(service, cacheDirectory, ttlSeconds: 300);
             var config = CreateCacheEnabledConfig(cacheDirectory, 300);
 
-            var first = await provider.GetTablePropertiesAsync(
+            var first = await provider.GetTableSchemaDetailsAsync(
                 config,
                 "https://help.kusto.windows.net",
                 "Samples",
                 "StormEvents",
+                refreshOfflineData: false,
                 CancellationToken.None);
 
-            var second = await provider.GetTablePropertiesAsync(
+            var second = await provider.GetTableSchemaDetailsAsync(
                 config,
                 "https://help.kusto.windows.net",
                 "Samples",
                 "StormEvents",
+                refreshOfflineData: false,
                 CancellationToken.None);
 
-            Assert.Equal(first["Schema"], second["Schema"]);
+            Assert.Equal(first.Columns.Rows.Count, second.Columns.Rows.Count);
             Assert.Single(service.ManagementCommands);
             Assert.Equal(".show database ['Samples'] schema as json", service.ManagementCommands[0]);
             Assert.Single(Directory.GetFiles(cacheDirectory));
@@ -80,7 +89,7 @@ public sealed class TableSchemaProviderTests
     }
 
     [Fact]
-    public async Task GetTablePropertiesAsync_WhenCacheExpires_RevalidatesWithIfLaterThan()
+    public async Task GetTableSchemaDetailsAsync_WhenCacheExpires_RevalidatesWithIfLaterThan()
     {
         var timeProvider = new FakeTimeProvider(DateTimeOffset.Parse("2026-03-06T00:00:00Z"));
         var service = new RecordingKustoService((_, _, command) =>
@@ -95,7 +104,8 @@ public sealed class TableSchemaProviderTests
                 "StormEvents",
                 1,
                 1,
-                ("State", "System.String")));
+                null,
+                ("State", "System.String", null)));
         });
         var cacheDirectory = CreateTemporaryDirectory();
 
@@ -104,12 +114,12 @@ public sealed class TableSchemaProviderTests
             var provider = CreateProvider(service, cacheDirectory, ttlSeconds: 60, timeProvider: timeProvider);
             var config = CreateCacheEnabledConfig(cacheDirectory, 60);
 
-            _ = await provider.GetTablePropertiesAsync(config, "https://help.kusto.windows.net", "Samples", "StormEvents", CancellationToken.None);
+            _ = await provider.GetTableSchemaDetailsAsync(config, "https://help.kusto.windows.net", "Samples", "StormEvents", false, CancellationToken.None);
 
             timeProvider.Advance(TimeSpan.FromMinutes(2));
 
-            _ = await provider.GetTablePropertiesAsync(config, "https://help.kusto.windows.net", "Samples", "StormEvents", CancellationToken.None);
-            _ = await provider.GetTablePropertiesAsync(config, "https://help.kusto.windows.net", "Samples", "StormEvents", CancellationToken.None);
+            _ = await provider.GetTableSchemaDetailsAsync(config, "https://help.kusto.windows.net", "Samples", "StormEvents", false, CancellationToken.None);
+            _ = await provider.GetTableSchemaDetailsAsync(config, "https://help.kusto.windows.net", "Samples", "StormEvents", false, CancellationToken.None);
 
             Assert.Equal(2, service.ManagementCommands.Count);
             Assert.Equal(".show database ['Samples'] schema as json", service.ManagementCommands[0]);
@@ -122,7 +132,7 @@ public sealed class TableSchemaProviderTests
     }
 
     [Fact]
-    public async Task GetTablePropertiesAsync_WhenCacheExpiresAndSchemaChanges_RefreshesCache()
+    public async Task GetTableSchemaDetailsAsync_WhenCacheExpiresAndSchemaChanges_RefreshesCache()
     {
         var timeProvider = new FakeTimeProvider(DateTimeOffset.Parse("2026-03-06T00:00:00Z"));
         var service = new RecordingKustoService((_, _, command) =>
@@ -134,8 +144,9 @@ public sealed class TableSchemaProviderTests
                     "StormEvents",
                     1,
                     2,
-                    ("State", "System.String"),
-                    ("EventId", "System.Int64")));
+                    null,
+                    ("State", "System.String", null),
+                    ("EventId", "System.Int64", null)));
             }
 
             return CreateDatabaseSchemaResult(CreateDatabaseSchemaJson(
@@ -143,7 +154,8 @@ public sealed class TableSchemaProviderTests
                 "StormEvents",
                 1,
                 1,
-                ("State", "System.String")));
+                null,
+                ("State", "System.String", null)));
         });
         var cacheDirectory = CreateTemporaryDirectory();
 
@@ -152,14 +164,13 @@ public sealed class TableSchemaProviderTests
             var provider = CreateProvider(service, cacheDirectory, ttlSeconds: 60, timeProvider: timeProvider);
             var config = CreateCacheEnabledConfig(cacheDirectory, 60);
 
-            var initial = await provider.GetTablePropertiesAsync(config, "https://help.kusto.windows.net", "Samples", "StormEvents", CancellationToken.None);
+            var initial = await provider.GetTableSchemaDetailsAsync(config, "https://help.kusto.windows.net", "Samples", "StormEvents", false, CancellationToken.None);
 
             timeProvider.Advance(TimeSpan.FromMinutes(2));
 
-            var refreshed = await provider.GetTablePropertiesAsync(config, "https://help.kusto.windows.net", "Samples", "StormEvents", CancellationToken.None);
+            var refreshed = await provider.GetTableSchemaDetailsAsync(config, "https://help.kusto.windows.net", "Samples", "StormEvents", false, CancellationToken.None);
 
-            Assert.NotEqual(initial["Schema"], refreshed["Schema"]);
-            Assert.Contains("EventId", refreshed["Schema"], StringComparison.Ordinal);
+            Assert.NotEqual(initial.Columns.Rows.Count, refreshed.Columns.Rows.Count);
             Assert.Equal(2, service.ManagementCommands.Count);
         }
         finally
@@ -169,7 +180,7 @@ public sealed class TableSchemaProviderTests
     }
 
     [Fact]
-    public async Task GetTablePropertiesAsync_WhenCacheFileIsCorrupt_RefetchesSchema()
+    public async Task GetTableSchemaDetailsAsync_WhenCacheFileIsCorrupt_RefetchesSchema()
     {
         const string clusterUrl = "https://help.kusto.windows.net";
         const string database = "Samples";
@@ -182,19 +193,21 @@ public sealed class TableSchemaProviderTests
             "StormEvents",
             1,
             1,
-            ("State", "System.String"))));
+            null,
+            ("State", "System.String", null))));
 
         try
         {
             var provider = CreateProvider(service, cacheDirectory, ttlSeconds: 300);
-            var properties = await provider.GetTablePropertiesAsync(
+            var details = await provider.GetTableSchemaDetailsAsync(
                 CreateCacheEnabledConfig(cacheDirectory, 300),
                 clusterUrl,
                 database,
                 "StormEvents",
+                refreshOfflineData: false,
                 CancellationToken.None);
 
-            Assert.Equal("StormEvents", properties["TableName"]);
+            Assert.Equal("StormEvents", details.Properties["TableName"]);
             Assert.Single(service.ManagementCommands);
         }
         finally
@@ -204,7 +217,58 @@ public sealed class TableSchemaProviderTests
     }
 
     [Fact]
-    public async Task GetTablePropertiesAsync_WhenFreshCacheDoesNotContainTable_RefreshesBeforeFailing()
+    public async Task GetTableSchemaDetailsAsync_WhenEmbeddedSchemaJsonIsMalformed_RefreshesSchema()
+    {
+        const string clusterUrl = "https://help.kusto.windows.net";
+        const string database = "Samples";
+        var cacheDirectory = CreateTemporaryDirectory();
+
+        try
+        {
+            var store = new OfflineTableDataStore(new SchemaCacheSettingsResolver(), NullLogger<OfflineTableDataStore>.Instance);
+            var config = CreateCacheEnabledConfig(cacheDirectory, 300);
+            await store.WriteEntryAsync(
+                config,
+                new DatabaseSchemaCacheEntry
+                {
+                    CacheFormatVersion = 1,
+                    ClusterUrl = clusterUrl,
+                    DatabaseName = database,
+                    CachedAtUtc = DateTimeOffset.UtcNow,
+                    SchemaVersion = "v1.1",
+                    SchemaJson = "{ bad json",
+                    TableNotes = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase)
+                },
+                CancellationToken.None);
+
+            var service = new RecordingKustoService((_, _, _) => CreateDatabaseSchemaResult(CreateDatabaseSchemaJson(
+                database,
+                "StormEvents",
+                1,
+                2,
+                null,
+                ("State", "System.String", null))));
+            var provider = CreateProvider(service, cacheDirectory, ttlSeconds: 300);
+
+            var details = await provider.GetTableSchemaDetailsAsync(
+                config,
+                clusterUrl,
+                database,
+                "StormEvents",
+                refreshOfflineData: false,
+                CancellationToken.None);
+
+            Assert.Equal("StormEvents", details.Properties["TableName"]);
+            Assert.Single(service.ManagementCommands);
+        }
+        finally
+        {
+            DeleteDirectory(cacheDirectory);
+        }
+    }
+
+    [Fact]
+    public async Task GetTableSchemaDetailsAsync_WhenFreshCacheDoesNotContainTable_RefreshesBeforeFailing()
     {
         var callCount = 0;
         var service = new RecordingKustoService((_, _, command) =>
@@ -216,8 +280,8 @@ public sealed class TableSchemaProviderTests
             }
 
             return callCount == 1
-                ? CreateDatabaseSchemaResult(CreateDatabaseSchemaJson("Samples", "OtherTable", 1, 1, ("State", "System.String")))
-                : CreateDatabaseSchemaResult(CreateDatabaseSchemaJson("Samples", "StormEvents", 1, 2, ("State", "System.String")));
+                ? CreateDatabaseSchemaResult(CreateDatabaseSchemaJson("Samples", "OtherTable", 1, 1, null, ("State", "System.String", null)))
+                : CreateDatabaseSchemaResult(CreateDatabaseSchemaJson("Samples", "StormEvents", 1, 2, null, ("State", "System.String", null)));
         });
         var cacheDirectory = CreateTemporaryDirectory();
 
@@ -226,23 +290,111 @@ public sealed class TableSchemaProviderTests
             var provider = CreateProvider(service, cacheDirectory, ttlSeconds: 300);
             var config = CreateCacheEnabledConfig(cacheDirectory, 300);
 
-            var initial = await provider.GetTablePropertiesAsync(
+            var initial = await provider.GetTableSchemaDetailsAsync(
                 config,
                 "https://help.kusto.windows.net",
                 "Samples",
                 "OtherTable",
+                refreshOfflineData: false,
                 CancellationToken.None);
 
-            var properties = await provider.GetTablePropertiesAsync(
+            var details = await provider.GetTableSchemaDetailsAsync(
                 config,
                 "https://help.kusto.windows.net",
                 "Samples",
                 "StormEvents",
+                refreshOfflineData: false,
                 CancellationToken.None);
 
-            Assert.Equal("OtherTable", initial["TableName"]);
-            Assert.Equal("StormEvents", properties["TableName"]);
+            Assert.Equal("OtherTable", initial.Properties["TableName"]);
+            Assert.Equal("StormEvents", details.Properties["TableName"]);
             Assert.Equal(2, service.ManagementCommands.Count);
+        }
+        finally
+        {
+            DeleteDirectory(cacheDirectory);
+        }
+    }
+
+    [Fact]
+    public async Task GetTableSchemaDetailsAsync_WhenRefreshOfflineDataRequested_WritesSchemaEvenWhenCacheDisabled()
+    {
+        var cacheDirectory = CreateTemporaryDirectory();
+        var service = new RecordingKustoService((_, _, _) => CreateDatabaseSchemaResult(CreateDatabaseSchemaJson(
+            "Samples",
+            "StormEvents",
+            1,
+            1,
+            null,
+            ("State", "System.String", null))));
+
+        try
+        {
+            var provider = CreateProvider(service, cacheDirectory, ttlSeconds: 300);
+            var config = new KustoConfig
+            {
+                SchemaCache = new SchemaCacheConfig
+                {
+                    Enabled = false,
+                    Path = cacheDirectory
+                }
+            };
+
+            _ = await provider.GetTableSchemaDetailsAsync(
+                config,
+                "https://help.kusto.windows.net",
+                "Samples",
+                "StormEvents",
+                refreshOfflineData: true,
+                CancellationToken.None);
+
+            Assert.Single(Directory.GetFiles(cacheDirectory));
+        }
+        finally
+        {
+            DeleteDirectory(cacheDirectory);
+        }
+    }
+
+    [Fact]
+    public async Task GetTableSchemaDetailsAsync_IncludesStoredNotesInOutput()
+    {
+        const string clusterUrl = "https://help.kusto.windows.net";
+        const string database = "Samples";
+        var cacheDirectory = CreateTemporaryDirectory();
+        Directory.CreateDirectory(cacheDirectory);
+        var cachePath = GetCachePath(cacheDirectory, clusterUrl, database);
+        var entry = new DatabaseSchemaCacheEntry
+        {
+            CacheFormatVersion = 1,
+            ClusterUrl = clusterUrl,
+            DatabaseName = database,
+            CachedAtUtc = DateTimeOffset.UtcNow,
+            SchemaVersion = "v1.1",
+            SchemaJson = CreateDatabaseSchemaJson(database, "StormEvents", 1, 1, "Table doc", ("State", "System.String", "State doc")),
+            TableNotes = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["StormEvents"] = ["Use for weather samples."]
+            }
+        };
+        await using (var stream = File.Create(cachePath))
+        {
+            await System.Text.Json.JsonSerializer.SerializeAsync(stream, entry, KustoJsonSerializerContext.Default.DatabaseSchemaCacheEntry);
+        }
+
+        try
+        {
+            var provider = CreateProvider(new RecordingKustoService((_, _, _) => throw new InvalidOperationException("Should use cache.")), cacheDirectory, ttlSeconds: 300);
+            var details = await provider.GetTableSchemaDetailsAsync(
+                CreateCacheEnabledConfig(cacheDirectory, 300),
+                clusterUrl,
+                database,
+                "StormEvents",
+                refreshOfflineData: false,
+                CancellationToken.None);
+
+            Assert.Equal("1", details.Properties["NoteCount"]);
+            Assert.Contains("Use for weather samples.", details.NotesMessage, StringComparison.Ordinal);
         }
         finally
         {
@@ -256,9 +408,12 @@ public sealed class TableSchemaProviderTests
         int ttlSeconds,
         TimeProvider? timeProvider = null)
     {
+        var resolver = new SchemaCacheSettingsResolver();
+        var store = new OfflineTableDataStore(resolver, NullLogger<OfflineTableDataStore>.Instance);
         return new TableSchemaProvider(
             service,
-            new SchemaCacheSettingsResolver(),
+            store,
+            resolver,
             NullLogger<TableSchemaProvider>.Instance,
             timeProvider ?? new FakeTimeProvider(DateTimeOffset.Parse("2026-03-06T00:00:00Z")));
     }
@@ -276,23 +431,33 @@ public sealed class TableSchemaProviderTests
         };
     }
 
-    private static TabularData CreateTableSchemaResult(string database, string tableName, string schemaJson)
-    {
-        return new TabularData(
-            ["TableName", "Schema", "DatabaseName"],
-            [[tableName, schemaJson, database]]);
-    }
-
     private static TabularData CreateDatabaseSchemaResult(string schemaJson)
     {
         return new TabularData(["DatabaseSchema"], [[schemaJson]]);
     }
 
-    private static string CreateDatabaseSchemaJson(string database, string tableName, int majorVersion, int minorVersion, params (string Name, string Type)[] columns)
+    private static string CreateDatabaseSchemaJson(
+        string database,
+        string tableName,
+        int majorVersion,
+        int minorVersion,
+        string? tableDocString,
+        params (string Name, string Type, string? DocString)[] columns)
     {
         var orderedColumns = string.Join(
             ",",
-            columns.Select(column => $$"""{"Name":"{{column.Name}}","Type":"{{column.Type}}"}"""));
+            columns.Select(column =>
+            {
+                var docStringProperty = column.DocString is null
+                    ? string.Empty
+                    : $",\"DocString\":\"{column.DocString}\"";
+
+                return $$"""{"Name":"{{column.Name}}","Type":"{{column.Type}}"{{docStringProperty}}}""";
+            }));
+
+        var tableDocStringProperty = tableDocString is null
+            ? string.Empty
+            : $",\"DocString\":\"{tableDocString}\"";
 
         return $$"""
             {
@@ -301,7 +466,7 @@ public sealed class TableSchemaProviderTests
                   "Name": "{{database}}",
                   "Tables": {
                     "{{tableName}}": {
-                      "Name": "{{tableName}}",
+                      "Name": "{{tableName}}"{{tableDocStringProperty}},
                       "OrderedColumns": [{{orderedColumns}}]
                     }
                   },


### PR DESCRIPTION
## Summary
- add offline table data management for table schema/docstrings and per-table notes
- add new table notes and offline-data CLI flows, including refresh, export, import, purge, and clear operations
- update tests, README, schema-cache docs, and Copilot guidance for the new behavior

## Validation
- dotnet build kusto.slnx --nologo
- dotnet test kusto.slnx --nologo
- manual CLI sanity check for notes/export/clear flows and prompt output separation

Closes #37