### PR TITLE
Support CSV output for query command

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Grab the relevant executable asset from the latest [release](https://github.com/
 - Render compatible `render` results as terminal charts with `--chart`, or as Mermaid in markdown output
 - Show optional query execution statistics with `--show-stats`
 - Basic public, US Government, and China cloud support for token audience selection and Web Explorer links
-- Multiple output formats (`human`, `json`, `markdown`/`md`)
+- Multiple output formats (`human`, `json`, `markdown`/`md`, plus query-only `csv`)
 - Optional offline table data with TTL-based schema revalidation, per-table notes, and import/export support
 - Configurable log verbosity with structured console/file logging
 - GitHub Actions workflows for PR validation, versioned native release assets, and release promotion
@@ -63,6 +63,9 @@ kusto query --chart "StormEvents | summarize Count=count() by State | top 5 by C
 # Emit Mermaid markdown for a compatible render query
 kusto query --format markdown --chart "StormEvents | summarize Count=count() by State | top 5 by Count desc | render piechart"
 
+# Redirect query results directly to CSV
+kusto query "StormEvents | summarize EventCount = count() by State | top 10 by EventCount desc" --format csv > top-states.csv
+
 # Need copy/paste examples?
 kusto examples
 ```
@@ -86,7 +89,7 @@ $env:KUSTO_CONFIG_PATH = "C:\temp\kusto\config.json"
 
 - `human`: renders compatible chart types directly in the terminal after the tabular results
 - `markdown`: emits Mermaid chart syntax for compatible chart kinds after the markdown table
-- `json`: rejected, because terminal/markdown chart rendering doesn't apply to JSON output
+- `json` / `csv`: rejected, because terminal/markdown chart rendering doesn't apply to JSON or CSV output
 
 Supported render kinds:
 
@@ -211,7 +214,7 @@ These options are available on all commands:
 
 | Option | Values | Default | Description |
 |---|---|---|---|
-| `--format` | `human`, `json`, `markdown`, `md` | `human` | Output format. |
+| `--format` | `human`, `json`, `markdown`, `md`, `csv` | `human` | Output format. `csv` is currently supported only for `query`. |
 | `--log-level` | `Trace`, `Debug`, `Information`, `Warning`, `Error`, `Critical`, `None` | not set | Enables console logging at the selected level (logs are always written to file). |
 | `-h`, `--help` | n/a | n/a | Show help. |
 | `--version` | n/a | n/a | Show version. |
@@ -255,8 +258,8 @@ These options are available on all commands:
 | `--force` | destructive `table` / `table notes` actions | Skip the confirmation prompt when clearing or purging offline data. Alias: `-f`. |
 | `--use` | `cluster add` | Also set the added cluster as the active/default cluster. |
 | `--file <path>` | `query` | Read query text from file. Alias: `-f`. Cannot be combined with inline query argument. |
-| `--chart` | `query` | Render compatible query results as a chart for `human` or `markdown` output. Not supported with `json`. |
-| `--show-stats` | `query` | Include query execution statistics when Kusto returns them. |
+| `--chart` | `query` | Render compatible query results as a chart for `human` or `markdown` output. Not supported with `json` or `csv`. |
+| `--show-stats` | `query` | Include query execution statistics when Kusto returns them. Not supported with `csv`. |
 
 ## Optional aliases
 
@@ -396,9 +399,12 @@ kusto database list --cluster help --format json
 
 # Markdown for docs/issues
 kusto query "StormEvents | take 3" --cluster help --database Samples --format markdown
+
+# CSV for redirecting query results
+kusto query "StormEvents | summarize EventCount = count() by State | top 10 by EventCount desc" --cluster help --database Samples --format csv > top-states.csv
 ```
 
-Human and markdown output show a short `Open in Web Explorer` link when available instead of printing the raw `webExplorerUrl`; JSON output still includes `webExplorerUrl`, and `--show-stats` adds `statistics`.
+Human and markdown output show a short `Open in Web Explorer` link when available instead of printing the raw `webExplorerUrl`; JSON output still includes `webExplorerUrl`, and `--show-stats` adds `statistics`. CSV output is query-only and writes just the tabular result data to stdout, so `--chart` and `--show-stats` are rejected with `--format csv`.
 
 ## Logging
 

--- a/src/Kusto.Cli/CliRunner.cs
+++ b/src/Kusto.Cli/CliRunner.cs
@@ -4,19 +4,46 @@ namespace Kusto.Cli;
 
 public static class CliRunner
 {
-    public static async Task<int> RunAsync(
+    private static readonly OutputFormat[] DefaultSupportedFormats =
+    [
+        OutputFormat.Human,
+        OutputFormat.Json,
+        OutputFormat.Markdown
+    ];
+
+    private static readonly OutputFormat[] RecognizedFormats =
+    [
+        OutputFormat.Human,
+        OutputFormat.Json,
+        OutputFormat.Markdown,
+        OutputFormat.Csv
+    ];
+
+    public static Task<int> RunAsync(
         string formatToken,
         string? logLevelToken,
         Func<CliRuntime, CancellationToken, Task<CliOutput>> commandAction,
         CancellationToken cancellationToken)
+        => RunAsync(formatToken, logLevelToken, commandAction, cancellationToken, DefaultSupportedFormats);
+
+    public static async Task<int> RunAsync(
+        string formatToken,
+        string? logLevelToken,
+        Func<CliRuntime, CancellationToken, Task<CliOutput>> commandAction,
+        CancellationToken cancellationToken,
+        params OutputFormat[] supportedFormats)
     {
         OutputFormat format;
         LogLevel? logLevel;
+        supportedFormats = supportedFormats is { Length: > 0 }
+            ? supportedFormats
+            : DefaultSupportedFormats;
 
         try
         {
             format = ParseOutputFormatToken(formatToken);
             logLevel = ParseLogLevelToken(logLevelToken);
+            EnsureSupportedOutputFormat(formatToken, format, supportedFormats);
         }
         catch (Exception ex)
         {
@@ -53,7 +80,9 @@ public static class CliRunner
             "json" => OutputFormat.Json,
             "markdown" => OutputFormat.Markdown,
             "md" => OutputFormat.Markdown,
-            _ => throw new UserFacingException($"'{formatToken}' is not a valid output format. Use one of: human, json, markdown, md.")
+            "csv" => OutputFormat.Csv,
+            _ => throw new UserFacingException(
+                $"'{formatToken}' is not a valid output format. Use one of: {DescribeOutputFormats(RecognizedFormats)}.")
         };
     }
 
@@ -107,5 +136,45 @@ public static class CliRunner
             tableOfflineDataManager,
             confirmationPrompt,
             formatter);
+    }
+
+    private static void EnsureSupportedOutputFormat(string formatToken, OutputFormat format, IReadOnlyCollection<OutputFormat> supportedFormats)
+    {
+        if (supportedFormats.Contains(format))
+        {
+            return;
+        }
+
+        throw new UserFacingException(
+            $"'{formatToken}' is not supported for this command. Use one of: {DescribeOutputFormats(supportedFormats)}.");
+    }
+
+    private static string DescribeOutputFormats(IEnumerable<OutputFormat> formats)
+    {
+        var uniqueFormats = new HashSet<OutputFormat>(formats);
+        var tokens = new List<string>();
+
+        if (uniqueFormats.Contains(OutputFormat.Human))
+        {
+            tokens.Add("human");
+        }
+
+        if (uniqueFormats.Contains(OutputFormat.Json))
+        {
+            tokens.Add("json");
+        }
+
+        if (uniqueFormats.Contains(OutputFormat.Markdown))
+        {
+            tokens.Add("markdown");
+            tokens.Add("md");
+        }
+
+        if (uniqueFormats.Contains(OutputFormat.Csv))
+        {
+            tokens.Add("csv");
+        }
+
+        return string.Join(", ", tokens);
     }
 }

--- a/src/Kusto.Cli/CommandFactory.cs
+++ b/src/Kusto.Cli/CommandFactory.cs
@@ -8,11 +8,11 @@ public static class CommandFactory
     {
         var formatOption = new Option<string>("--format")
         {
-            Description = "Output format for people or tools: human, json, markdown, md.",
+            Description = "Output format for people or tools: human, json, markdown, md, csv (query only).",
             Recursive = true,
             DefaultValueFactory = _ => "human"
         };
-        formatOption.AcceptOnlyFromAmong("human", "json", "markdown", "md");
+        formatOption.AcceptOnlyFromAmong("human", "json", "markdown", "md", "csv");
 
         var logLevelOption = new Option<string?>("--log-level")
         {
@@ -55,6 +55,7 @@ public static class CommandFactory
                             ["Run KQL", "kusto query \"StormEvents | take 5\" --cluster help --database Samples"],
                             ["Run KQL", "kusto query --chart \"StormEvents | summarize Count=count() by State | top 5 by Count desc | render columnchart\" --cluster help --database Samples"],
                             ["Run KQL", "kusto query --format markdown --chart \"StormEvents | summarize Count=count() by State | top 5 by Count desc | render piechart\" --cluster help --database Samples"],
+                            ["Run KQL", "kusto query \"StormEvents | summarize EventCount=count() by State | top 10 by EventCount desc\" --format csv --cluster help --database Samples > top-states.csv"],
                             ["Run KQL", "kusto query --file .\\queries\\top-states.kql --cluster help --database Samples"],
                             ["Optional aliases", "aliases | clusters | db | databases | tables | ls | get | schema | rm | delete | use | run | exec | --db | --limit | -f"]
                         ])
@@ -834,9 +835,15 @@ public static class CommandFactory
                 var isJsonOutput = string.Equals(format, "json", StringComparison.OrdinalIgnoreCase);
                 var isMarkdownOutput = string.Equals(format, "markdown", StringComparison.OrdinalIgnoreCase) ||
                     string.Equals(format, "md", StringComparison.OrdinalIgnoreCase);
-                if (showChart && isJsonOutput)
+                var isCsvOutput = string.Equals(format, "csv", StringComparison.OrdinalIgnoreCase);
+                if (showChart && (isJsonOutput || isCsvOutput))
                 {
-                    throw new UserFacingException("--chart can't be used with --format json.");
+                    throw new UserFacingException($"--chart can't be used with --format {format.ToLowerInvariant()}.");
+                }
+
+                if (showStats && isCsvOutput)
+                {
+                    throw new UserFacingException("--show-stats can't be used with --format csv.");
                 }
 
                 var config = await runtime.ConfigStore.LoadAsync(ct);
@@ -892,7 +899,7 @@ public static class CommandFactory
                             }
                         }
                     }
-                    else if (!isMarkdownOutput && compatibility.HumanChart is not null)
+                    else if (!isMarkdownOutput && !isCsvOutput && compatibility.HumanChart is not null)
                     {
                         chartHint = "This query can be rendered as a terminal chart. Re-run with --chart to see it.";
                     }
@@ -911,7 +918,7 @@ public static class CommandFactory
                     MarkdownChart = markdownChart,
                     IsQueryResultTable = true
                 };
-            }, cancellationToken);
+            }, cancellationToken, OutputFormat.Human, OutputFormat.Json, OutputFormat.Markdown, OutputFormat.Csv);
         });
 
         return queryCommand;

--- a/src/Kusto.Cli/Contracts.cs
+++ b/src/Kusto.Cli/Contracts.cs
@@ -138,5 +138,6 @@ public enum OutputFormat
 {
     Human,
     Json,
-    Markdown
+    Markdown,
+    Csv
 }

--- a/src/Kusto.Cli/OutputFormatter.cs
+++ b/src/Kusto.Cli/OutputFormatter.cs
@@ -12,6 +12,7 @@ public sealed class OutputFormatter : IOutputFormatter
         {
             OutputFormat.Json => JsonSerializer.Serialize(output, KustoJsonSerializerContext.Default.CliOutput),
             OutputFormat.Markdown => FormatMarkdown(output),
+            OutputFormat.Csv => FormatCsv(output),
             _ => FormatHuman(output)
         };
     }
@@ -118,6 +119,24 @@ public sealed class OutputFormatter : IOutputFormatter
         }
 
         return buffer.ToString().TrimEnd();
+    }
+
+    private static string FormatCsv(CliOutput output)
+    {
+        if (output.Table is not { Columns.Count: > 0 } table)
+        {
+            return string.Empty;
+        }
+
+        var buffer = new StringBuilder();
+        AppendCsvRow(buffer, table.Columns);
+
+        foreach (var row in table.Rows)
+        {
+            AppendCsvRow(buffer, row);
+        }
+
+        return buffer.ToString().TrimEnd('\r', '\n');
     }
 
     private static Dictionary<string, string?> BuildDisplayProperties(CliOutput output)
@@ -228,6 +247,37 @@ public sealed class OutputFormatter : IOutputFormatter
         {
             properties[key] = value;
         }
+    }
+
+    private static void AppendCsvRow(StringBuilder buffer, IEnumerable<string?> values)
+    {
+        var firstValue = true;
+        foreach (var value in values)
+        {
+            if (!firstValue)
+            {
+                buffer.Append(',');
+            }
+
+            buffer.Append(EscapeCsvValue(value));
+            firstValue = false;
+        }
+
+        buffer.AppendLine();
+    }
+
+    private static string EscapeCsvValue(string? value)
+    {
+        var text = value ?? string.Empty;
+        if (!text.Contains(',', StringComparison.Ordinal) &&
+            !text.Contains('"', StringComparison.Ordinal) &&
+            !text.Contains('\r') &&
+            !text.Contains('\n'))
+        {
+            return text;
+        }
+
+        return $"\"{text.Replace("\"", "\"\"", StringComparison.Ordinal)}\"";
     }
 
     private static string BuildHumanTextOutput(CliOutput output, int? availableWidth)

--- a/tests/Kusto.Cli.Tests/OutputFormatterTests.cs
+++ b/tests/Kusto.Cli.Tests/OutputFormatterTests.cs
@@ -100,6 +100,87 @@ public sealed class OutputFormatterTests
     }
 
     [Fact]
+    public void FormatCsv_TableOutput_UsesHeadersAndRows()
+    {
+        var formatter = new OutputFormatter();
+        var output = new CliOutput
+        {
+            Table = new TabularData(
+                ["Name", "Count"],
+                [
+                    ["alpha", "42"],
+                    ["beta", "7"]
+                ])
+        };
+
+        var rendered = formatter.Format(output, OutputFormat.Csv);
+
+        var expected = string.Join(Environment.NewLine, ["Name,Count", "alpha,42", "beta,7"]);
+        Assert.Equal(expected, rendered);
+    }
+
+    [Fact]
+    public void FormatCsv_TableOutput_EscapesSpecialCharacters()
+    {
+        var formatter = new OutputFormatter();
+        var output = new CliOutput
+        {
+            Table = new TabularData(
+                ["Name", "Notes", "Quote"],
+                [
+                    ["alpha,beta", $"line1{Environment.NewLine}line2", "he said \"hi\""]
+                ])
+        };
+
+        var rendered = formatter.Format(output, OutputFormat.Csv);
+
+        var expected = string.Join(
+            Environment.NewLine,
+            [
+                "Name,Notes,Quote",
+                $"\"alpha,beta\",\"line1{Environment.NewLine}line2\",\"he said \"\"hi\"\"\""
+            ]);
+        Assert.Equal(expected, rendered);
+    }
+
+    [Fact]
+    public void FormatCsv_QueryOutput_IgnoresNonTabularMetadata()
+    {
+        var formatter = new OutputFormatter();
+        var output = new CliOutput
+        {
+            Message = "not included",
+            Properties = new Dictionary<string, string?> { ["Name"] = "Samples" },
+            Table = new TabularData(["Name"], [["alpha"]]),
+            WebExplorerUrl = "https://dataexplorer.azure.com/",
+            Statistics = new QueryStatistics { ExecutionTimeSec = 1.23 },
+            Visualization = new QueryVisualization { Visualization = "piechart" },
+            ChartHint = "hint",
+            ChartMessage = "message",
+            HumanChart = "chart",
+            MarkdownChart = "```mermaid```"
+        };
+
+        var rendered = formatter.Format(output, OutputFormat.Csv);
+
+        Assert.Equal(string.Join(Environment.NewLine, ["Name", "alpha"]), rendered);
+    }
+
+    [Fact]
+    public void FormatCsv_WithoutTable_ReturnsEmptyString()
+    {
+        var formatter = new OutputFormatter();
+        var output = new CliOutput
+        {
+            Message = "hello"
+        };
+
+        var rendered = formatter.Format(output, OutputFormat.Csv);
+
+        Assert.Equal(string.Empty, rendered);
+    }
+
+    [Fact]
     public void FormatHuman_QueryOutput_HidesWebExplorerUrlByDefault()
     {
         var formatter = new OutputFormatter();

--- a/tests/Kusto.Cli.Tests/ParserTests.cs
+++ b/tests/Kusto.Cli.Tests/ParserTests.cs
@@ -13,10 +13,18 @@ public sealed class ParserTests
     }
 
     [Fact]
+    public void Parse_AllowsCsvFormat()
+    {
+        var rootCommand = CommandFactory.CreateRootCommand();
+        var result = rootCommand.Parse(["query", "print 1", "--format", "csv"], new ParserConfiguration());
+        Assert.Empty(result.Errors);
+    }
+
+    [Fact]
     public void Parse_RejectsUnknownFormat()
     {
         var rootCommand = CommandFactory.CreateRootCommand();
-        var result = rootCommand.Parse(["cluster", "list", "--format", "csv"], new ParserConfiguration());
+        var result = rootCommand.Parse(["cluster", "list", "--format", "xml"], new ParserConfiguration());
         Assert.NotEmpty(result.Errors);
     }
 

--- a/tests/Kusto.Cli.Tests/QueryCommandTests.cs
+++ b/tests/Kusto.Cli.Tests/QueryCommandTests.cs
@@ -17,6 +17,72 @@ public sealed class QueryCommandTests
     }
 
     [Fact]
+    public async Task Query_WithCsvFormatAndChart_ReturnsError()
+    {
+        var rootCommand = CommandFactory.CreateRootCommand();
+        var originalError = Console.Error;
+        using var errorWriter = new StringWriter();
+        Console.SetError(errorWriter);
+
+        try
+        {
+            var exitCode = await rootCommand.Parse(["--format", "csv", "query", "print 1", "--chart"], new ParserConfiguration())
+                .InvokeAsync();
+
+            Assert.Equal(1, exitCode);
+            Assert.Contains("--chart can't be used with --format csv.", errorWriter.ToString(), StringComparison.Ordinal);
+        }
+        finally
+        {
+            Console.SetError(originalError);
+        }
+    }
+
+    [Fact]
+    public async Task Query_WithCsvFormatAndShowStats_ReturnsError()
+    {
+        var rootCommand = CommandFactory.CreateRootCommand();
+        var originalError = Console.Error;
+        using var errorWriter = new StringWriter();
+        Console.SetError(errorWriter);
+
+        try
+        {
+            var exitCode = await rootCommand.Parse(["--format", "csv", "query", "print 1", "--show-stats"], new ParserConfiguration())
+                .InvokeAsync();
+
+            Assert.Equal(1, exitCode);
+            Assert.Contains("--show-stats can't be used with --format csv.", errorWriter.ToString(), StringComparison.Ordinal);
+        }
+        finally
+        {
+            Console.SetError(originalError);
+        }
+    }
+
+    [Fact]
+    public async Task ClusterList_WithCsvFormat_ReturnsError()
+    {
+        var rootCommand = CommandFactory.CreateRootCommand();
+        var originalError = Console.Error;
+        using var errorWriter = new StringWriter();
+        Console.SetError(errorWriter);
+
+        try
+        {
+            var exitCode = await rootCommand.Parse(["cluster", "list", "--format", "csv"], new ParserConfiguration())
+                .InvokeAsync();
+
+            Assert.Equal(1, exitCode);
+            Assert.Contains("'csv' is not supported for this command.", errorWriter.ToString(), StringComparison.Ordinal);
+        }
+        finally
+        {
+            Console.SetError(originalError);
+        }
+    }
+
+    [Fact]
     public async Task Query_WithInvalidSyntax_ReturnsValidationError()
     {
         var rootCommand = CommandFactory.CreateRootCommand();


### PR DESCRIPTION
Fixes #43

## Summary
- add csv as a query-only output format
- render query tables as clean CSV with escaping for commas, quotes, and newlines
- reject --chart and --show-stats with --format csv and document the behavior