### PR TITLE
Improve default formatting of values in human query results

### DIFF
--- a/src/Kusto.Cli/Hex1bHumanRenderer.cs
+++ b/src/Kusto.Cli/Hex1bHumanRenderer.cs
@@ -94,6 +94,8 @@ internal static class Hex1bHumanRenderer
             return FormatDataTable(new TabularData(["Value"], data.Rows), isQueryResultTable: false, maxWidth);
         }
 
+        data = FormatQueryValuesForDisplay(data);
+
         var columnCount = data.Columns.Count;
         var headerLines = data.Columns
             .Select(header => SplitCellLines(header).AsReadOnly())
@@ -413,6 +415,192 @@ internal static class Hex1bHumanRenderer
         }
 
         return hasValue;
+    }
+
+    private static readonly string[] KustoDateTimeFormats =
+    [
+        "yyyy-MM-dd'T'HH:mm:ss'Z'",
+        "yyyy-MM-dd'T'HH:mm:ss.FFFFFFF'Z'"
+    ];
+
+    internal static TabularData FormatQueryValuesForDisplay(TabularData data)
+    {
+        if (data.Rows.Count == 0 || data.Columns.Count == 0)
+        {
+            return data;
+        }
+
+        var columnCount = data.Columns.Count;
+        var formats = new ColumnDisplayFormat[columnCount];
+        var anyFormatted = false;
+
+        for (var i = 0; i < columnCount; i++)
+        {
+            formats[i] = DetectColumnDisplayFormat(data, i);
+            if (formats[i] != ColumnDisplayFormat.None)
+            {
+                anyFormatted = true;
+            }
+        }
+
+        if (!anyFormatted)
+        {
+            return data;
+        }
+
+        var formattedRows = new IReadOnlyList<string?>[data.Rows.Count];
+        for (var rowIndex = 0; rowIndex < data.Rows.Count; rowIndex++)
+        {
+            var row = data.Rows[rowIndex];
+            var formatted = new string?[columnCount];
+            for (var i = 0; i < columnCount; i++)
+            {
+                var value = i < row.Count ? row[i] : null;
+                formatted[i] = formats[i] switch
+                {
+                    ColumnDisplayFormat.Integer => FormatIntegerValue(value),
+                    ColumnDisplayFormat.DateTime => FormatDateTimeValue(value),
+                    _ => value
+                };
+            }
+
+            formattedRows[rowIndex] = formatted;
+        }
+
+        return new TabularData(data.Columns, formattedRows);
+    }
+
+    private enum ColumnDisplayFormat
+    {
+        None,
+        Integer,
+        DateTime
+    }
+
+    private static ColumnDisplayFormat DetectColumnDisplayFormat(TabularData data, int columnIndex)
+    {
+        var couldBeInteger = true;
+        var couldBeDateTime = true;
+        var hasValue = false;
+
+        foreach (var row in data.Rows)
+        {
+            if (columnIndex >= row.Count)
+            {
+                continue;
+            }
+
+            var value = row[columnIndex];
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                continue;
+            }
+
+            hasValue = true;
+
+            if (couldBeInteger)
+            {
+                couldBeInteger = IsFormattableInteger(value);
+            }
+
+            if (couldBeDateTime)
+            {
+                couldBeDateTime = IsKustoDateTimeFormat(value);
+            }
+
+            if (!couldBeInteger && !couldBeDateTime)
+            {
+                break;
+            }
+        }
+
+        if (!hasValue)
+        {
+            return ColumnDisplayFormat.None;
+        }
+
+        if (couldBeDateTime)
+        {
+            return ColumnDisplayFormat.DateTime;
+        }
+
+        if (couldBeInteger)
+        {
+            return ColumnDisplayFormat.Integer;
+        }
+
+        return ColumnDisplayFormat.None;
+    }
+
+    private static bool IsFormattableInteger(string value)
+    {
+        if (value.Length == 0)
+        {
+            return false;
+        }
+
+        // Reject leading '+' (could be a non-numeric identifier)
+        if (value[0] == '+')
+        {
+            return false;
+        }
+
+        // Reject leading zeros (could be an ID like "00123"), except "0" and "-0"
+        var digitStart = value[0] == '-' ? 1 : 0;
+        if (digitStart < value.Length - 1 && value[digitStart] == '0')
+        {
+            return false;
+        }
+
+        return long.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out _);
+    }
+
+    private static bool IsKustoDateTimeFormat(string value)
+    {
+        return DateTimeOffset.TryParseExact(
+            value,
+            KustoDateTimeFormats,
+            CultureInfo.InvariantCulture,
+            DateTimeStyles.None,
+            out _);
+    }
+
+    private static string? FormatIntegerValue(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return value;
+        }
+
+        if (!long.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var number))
+        {
+            return value;
+        }
+
+        return number.ToString("N0", CultureInfo.InvariantCulture);
+    }
+
+    private static string? FormatDateTimeValue(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return value;
+        }
+
+        if (!DateTimeOffset.TryParseExact(value, KustoDateTimeFormats, CultureInfo.InvariantCulture, DateTimeStyles.None, out var dt))
+        {
+            return value;
+        }
+
+        if (dt.TimeOfDay == TimeSpan.Zero)
+        {
+            return dt.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+        }
+
+        var hasFractionalSeconds = dt.TimeOfDay.Ticks % TimeSpan.TicksPerSecond != 0;
+        return hasFractionalSeconds
+            ? dt.ToString("yyyy-MM-dd HH:mm:ss.FFFFFFF", CultureInfo.InvariantCulture)
+            : dt.ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture);
     }
 
     private static int[] FitWidths(int[] naturalWidths, int? maxWidth, int minimumWidth, int frameWidth)

--- a/tests/Kusto.Cli.Tests/Hex1bHumanRendererTests.cs
+++ b/tests/Kusto.Cli.Tests/Hex1bHumanRendererTests.cs
@@ -91,4 +91,231 @@ public sealed class Hex1bHumanRendererTests
         Assert.Contains("Value", rendered, StringComparison.Ordinal);
         Assert.Contains("Column10", rendered, StringComparison.Ordinal);
     }
+
+    [Fact]
+    public void FormatQueryValuesForDisplay_IntegerColumn_AddsThousandsSeparators()
+    {
+        var table = new TabularData(
+            ["Name", "RowCount"],
+            [
+                ["Events", "66380993"],
+                ["Metrics", "19639740"]
+            ]);
+
+        var formatted = Hex1bHumanRenderer.FormatQueryValuesForDisplay(table);
+
+        Assert.Equal("66,380,993", formatted.Rows[0][1]);
+        Assert.Equal("19,639,740", formatted.Rows[1][1]);
+        Assert.Equal("Events", formatted.Rows[0][0]);
+    }
+
+    [Fact]
+    public void FormatQueryValuesForDisplay_SmallIntegers_NoUnnecessarySeparators()
+    {
+        var table = new TabularData(
+            ["Name", "Count"],
+            [
+                ["alpha", "42"],
+                ["beta", "0"],
+                ["gamma", "-1"]
+            ]);
+
+        var formatted = Hex1bHumanRenderer.FormatQueryValuesForDisplay(table);
+
+        Assert.Equal("42", formatted.Rows[0][1]);
+        Assert.Equal("0", formatted.Rows[1][1]);
+        Assert.Equal("-1", formatted.Rows[2][1]);
+    }
+
+    [Fact]
+    public void FormatQueryValuesForDisplay_NegativeIntegers_FormattedWithSeparators()
+    {
+        var table = new TabularData(
+            ["Metric", "Value"],
+            [
+                ["delta", "-1234567"]
+            ]);
+
+        var formatted = Hex1bHumanRenderer.FormatQueryValuesForDisplay(table);
+
+        Assert.Equal("-1,234,567", formatted.Rows[0][1]);
+    }
+
+    [Fact]
+    public void FormatQueryValuesForDisplay_LeadingZeroStrings_NotFormatted()
+    {
+        var table = new TabularData(
+            ["Id"],
+            [
+                ["00123"],
+                ["00456"]
+            ]);
+
+        var formatted = Hex1bHumanRenderer.FormatQueryValuesForDisplay(table);
+
+        Assert.Equal("00123", formatted.Rows[0][0]);
+        Assert.Equal("00456", formatted.Rows[1][0]);
+    }
+
+    [Fact]
+    public void FormatQueryValuesForDisplay_MidnightDateTimes_StripsTimeComponent()
+    {
+        var table = new TabularData(
+            ["Day", "RowCount"],
+            [
+                ["2026-02-27T00:00:00Z", "66380993"],
+                ["2026-02-28T00:00:00Z", "19639740"]
+            ]);
+
+        var formatted = Hex1bHumanRenderer.FormatQueryValuesForDisplay(table);
+
+        Assert.Equal("2026-02-27", formatted.Rows[0][0]);
+        Assert.Equal("2026-02-28", formatted.Rows[1][0]);
+        Assert.Equal("66,380,993", formatted.Rows[0][1]);
+    }
+
+    [Fact]
+    public void FormatQueryValuesForDisplay_NonMidnightDateTimes_ShowsReadableFormat()
+    {
+        var table = new TabularData(
+            ["Timestamp"],
+            [
+                ["2026-03-10T14:30:15Z"],
+                ["2026-03-10T08:00:00Z"]
+            ]);
+
+        var formatted = Hex1bHumanRenderer.FormatQueryValuesForDisplay(table);
+
+        Assert.Equal("2026-03-10 14:30:15", formatted.Rows[0][0]);
+        Assert.Equal("2026-03-10 08:00:00", formatted.Rows[1][0]);
+    }
+
+    [Fact]
+    public void FormatQueryValuesForDisplay_DateTimesWithFractionalSeconds_PreservesFractionalPart()
+    {
+        var table = new TabularData(
+            ["Timestamp"],
+            [
+                ["2026-03-10T14:30:15.1234567Z"]
+            ]);
+
+        var formatted = Hex1bHumanRenderer.FormatQueryValuesForDisplay(table);
+
+        Assert.Equal("2026-03-10 14:30:15.1234567", formatted.Rows[0][0]);
+    }
+
+    [Fact]
+    public void FormatQueryValuesForDisplay_MixedColumnTypes_LeavesNonUniformColumnsUnformatted()
+    {
+        var table = new TabularData(
+            ["Value"],
+            [
+                ["66380993"],
+                ["not-a-number"]
+            ]);
+
+        var formatted = Hex1bHumanRenderer.FormatQueryValuesForDisplay(table);
+
+        Assert.Equal("66380993", formatted.Rows[0][0]);
+        Assert.Equal("not-a-number", formatted.Rows[1][0]);
+    }
+
+    [Fact]
+    public void FormatQueryValuesForDisplay_NullAndEmptyValues_HandledGracefully()
+    {
+        var table = new TabularData(
+            ["Day", "Count"],
+            [
+                ["2026-02-27T00:00:00Z", "66380993"],
+                [null, null],
+                ["2026-03-01T00:00:00Z", ""]
+            ]);
+
+        var formatted = Hex1bHumanRenderer.FormatQueryValuesForDisplay(table);
+
+        Assert.Equal("2026-02-27", formatted.Rows[0][0]);
+        Assert.Equal("66,380,993", formatted.Rows[0][1]);
+        Assert.Null(formatted.Rows[1][0]);
+        Assert.Null(formatted.Rows[1][1]);
+        Assert.Equal("2026-03-01", formatted.Rows[2][0]);
+        Assert.Equal("", formatted.Rows[2][1]);
+    }
+
+    [Fact]
+    public void FormatQueryValuesForDisplay_DoubleValues_LeftUnformatted()
+    {
+        var table = new TabularData(
+            ["Average"],
+            [
+                ["66380993.456"],
+                ["1.23"]
+            ]);
+
+        var formatted = Hex1bHumanRenderer.FormatQueryValuesForDisplay(table);
+
+        Assert.Equal("66380993.456", formatted.Rows[0][0]);
+        Assert.Equal("1.23", formatted.Rows[1][0]);
+    }
+
+    [Fact]
+    public void FormatQueryValuesForDisplay_EmptyTable_ReturnsOriginal()
+    {
+        var table = new TabularData(["Name", "Count"], []);
+
+        var formatted = Hex1bHumanRenderer.FormatQueryValuesForDisplay(table);
+
+        Assert.Same(table, formatted);
+    }
+
+    [Fact]
+    public void FormatQueryValuesForDisplay_NonQueryTable_NotFormatted()
+    {
+        // Non-query tables (IsQueryResultTable = false) go through FormatDataTable,
+        // not FormatCompactQueryTable, so formatting is NOT applied
+        var table = new TabularData(
+            ["Name", "Count"],
+            [
+                ["Events", "66380993"]
+            ]);
+
+        var rendered = Hex1bHumanRenderer.FormatDataTable(table, isQueryResultTable: false);
+
+        Assert.Contains("66380993", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain("66,380,993", rendered, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void FormatDataTable_QueryResults_FormatsIntegersWithThousandsSeparators()
+    {
+        var table = new TabularData(
+            ["Day", "RowCount"],
+            [
+                ["2026-02-27T00:00:00Z", "66380993"],
+                ["2026-02-28T00:00:00Z", "19639740"]
+            ]);
+
+        var rendered = Hex1bHumanRenderer.FormatDataTable(table, isQueryResultTable: true);
+
+        Assert.Contains("2026-02-27", rendered, StringComparison.Ordinal);
+        Assert.Contains("66,380,993", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain("T00:00:00Z", rendered, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void FormatDataTable_QueryResults_FormattedIntegersRemainRightAligned()
+    {
+        var table = new TabularData(
+            ["Name", "Count"],
+            [
+                ["alpha", "1234567"],
+                ["beta", "42"]
+            ]);
+
+        var rendered = Hex1bHumanRenderer.FormatDataTable(table, isQueryResultTable: true);
+
+        Assert.Contains("1,234,567", rendered, StringComparison.Ordinal);
+        Assert.Contains("42", rendered, StringComparison.Ordinal);
+        // Verify right-alignment: "42" should have leading spaces
+        Assert.Contains("       42", rendered, StringComparison.Ordinal);
+    }
 }

--- a/tests/Kusto.Cli.Tests/OutputFormatterTests.cs
+++ b/tests/Kusto.Cli.Tests/OutputFormatterTests.cs
@@ -411,4 +411,28 @@ public sealed class OutputFormatterTests
         Assert.Contains("```mermaid", rendered, StringComparison.Ordinal);
         Assert.Contains("pie showData", rendered, StringComparison.Ordinal);
     }
+
+    [Theory]
+    [InlineData(OutputFormat.Json)]
+    [InlineData(OutputFormat.Markdown)]
+    [InlineData(OutputFormat.Csv)]
+    public void Format_NonHumanOutputFormats_PreserveRawValues(OutputFormat format)
+    {
+        var formatter = new OutputFormatter();
+        var output = new CliOutput
+        {
+            IsQueryResultTable = true,
+            Table = new TabularData(
+                ["Day", "RowCount"],
+                [
+                    ["2026-02-27T00:00:00Z", "66380993"]
+                ])
+        };
+
+        var rendered = formatter.Format(output, format);
+
+        Assert.Contains("2026-02-27T00:00:00Z", rendered, StringComparison.Ordinal);
+        Assert.Contains("66380993", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain("66,380,993", rendered, StringComparison.Ordinal);
+    }
 }


### PR DESCRIPTION
Apply human-friendly formatting to query result table values in human output:

- **DateTime values**: Strip time component when midnight (e.g., \2026-02-27T00:00:00Z\ → \2026-02-27\), otherwise show readable format with space separator (\2026-03-10T14:30:15Z\ → \2026-03-10 14:30:15\)
- **Integer values**: Add thousands separators (e.g., \66380993\ → \66,380,993\)

### Before
\\\
Day                   RowCount
────────────────────  ────────
2026-02-27T00:00:00Z  66380993
2026-02-28T00:00:00Z  19639740
\\\

### After
\\\
Day         RowCount
──────────  ──────────
2026-02-27  66,380,993
2026-02-28  19,639,740
\\\

### Design decisions
- Formatting only applies to **human output** for **query result tables**. JSON, markdown, and CSV output preserve raw values.
- Column type detection uses conservative heuristics: integers must not have leading zeros or explicit plus signs, and datetimes must match Kusto's strict ISO 8601 format (\TryParseExact\).
- Only \long\ integers are formatted (not doubles/decimals) to avoid precision issues.
- Formatted integers still right-align correctly since \decimal.TryParse\ with \NumberStyles.Number\ handles thousands separators.

Closes #42