### PR TITLE
Improve default formatting of values in displayed query results

### DIFF
--- a/src/Kusto.Cli/Hex1bHumanRenderer.cs
+++ b/src/Kusto.Cli/Hex1bHumanRenderer.cs
@@ -95,10 +95,21 @@ internal static class Hex1bHumanRenderer
         }
 
         var columnCount = data.Columns.Count;
-        var headerLines = data.Columns
+
+        // Detect column alignment from raw (unformatted) data
+        var rightAlignedColumns = new bool[columnCount];
+        for (var i = 0; i < columnCount; i++)
+        {
+            rightAlignedColumns[i] = ShouldRightAlignColumn(data, i);
+        }
+
+        // Format cell values for human display (thousand separators, smart datetimes)
+        var displayData = FormatQueryTableForDisplay(data);
+
+        var headerLines = displayData.Columns
             .Select(header => SplitCellLines(header).AsReadOnly())
             .ToArray();
-        var normalizedRows = data.Rows
+        var normalizedRows = displayData.Rows
             .Select(row => Enumerable.Range(0, columnCount)
                 .Select(index => index < row.Count ? SplitCellLines(row[index]) : [string.Empty])
                 .ToArray())
@@ -118,16 +129,10 @@ internal static class Hex1bHumanRenderer
             }
         }
 
-        var rightAlignedColumns = new bool[columnCount];
-        for (var i = 0; i < columnCount; i++)
-        {
-            rightAlignedColumns[i] = ShouldRightAlignColumn(data, i);
-        }
-
         widths = FitWidths(widths, maxWidth, minimumWidth: 3, frameWidth: GetCompactTableFrameWidth(columnCount));
-        if (ShouldUseRecordLayout(data, widths, maxWidth))
+        if (ShouldUseRecordLayout(displayData, widths, maxWidth))
         {
-            return FormatQueryRowsAsRecords(data, maxWidth);
+            return FormatQueryRowsAsRecords(displayData, maxWidth);
         }
 
         var wrappedHeaders = WrapCells(headerLines, widths);
@@ -144,6 +149,71 @@ internal static class Hex1bHumanRenderer
         }
 
         return builder.ToString().TrimEnd();
+    }
+
+    private static TabularData FormatQueryTableForDisplay(TabularData data)
+    {
+        var formattedRows = new List<IReadOnlyList<string?>>(data.Rows.Count);
+        foreach (var row in data.Rows)
+        {
+            var formattedRow = new string?[row.Count];
+            for (var i = 0; i < row.Count; i++)
+            {
+                formattedRow[i] = FormatCellValueForDisplay(row[i]);
+            }
+
+            formattedRows.Add(formattedRow);
+        }
+
+        return new TabularData(data.Columns, formattedRows);
+    }
+
+    internal static string? FormatCellValueForDisplay(string? value)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            return value;
+        }
+
+        // Skip zero-padded values that are likely identifiers (e.g., "001234")
+        var numericStart = value[0] == '-' ? 1 : 0;
+        if (value.Length > numericStart + 1 && value[numericStart] == '0' && char.IsDigit(value[numericStart + 1]))
+        {
+            return value;
+        }
+
+        if (long.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var longValue))
+        {
+            return longValue.ToString("N0", CultureInfo.InvariantCulture);
+        }
+
+        if (decimal.TryParse(value, NumberStyles.AllowLeadingSign | NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture, out var decimalValue))
+        {
+            var dotIndex = value.IndexOf('.');
+            if (dotIndex >= 0)
+            {
+                var decimalPlaces = value.Length - dotIndex - 1;
+                return decimalValue.ToString($"N{decimalPlaces}", CultureInfo.InvariantCulture);
+            }
+
+            return decimalValue.ToString("N0", CultureInfo.InvariantCulture);
+        }
+
+        // Format ISO 8601 datetime strings (YYYY-MM-DDTHH:mm:ss...)
+        if (value.Length >= 20 &&
+            char.IsDigit(value[0]) && value[4] == '-' && value[7] == '-' && value[10] == 'T' &&
+            DateTimeOffset.TryParse(value, CultureInfo.InvariantCulture, DateTimeStyles.None, out var dateTimeValue))
+        {
+            if (dateTimeValue.TimeOfDay == TimeSpan.Zero)
+            {
+                return dateTimeValue.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+            }
+
+            // Non-midnight: replace T with space for readability, preserving timezone
+            return string.Concat(value.AsSpan(0, 10), " ", value.AsSpan(11));
+        }
+
+        return value;
     }
 
     private static string FormatQueryRowsAsRecords(TabularData data, int? maxWidth)

--- a/tests/Kusto.Cli.Tests/Hex1bHumanRendererTests.cs
+++ b/tests/Kusto.Cli.Tests/Hex1bHumanRendererTests.cs
@@ -21,6 +21,138 @@ public sealed class Hex1bHumanRendererTests
     }
 
     [Fact]
+    public void FormatDataTable_QueryResults_FormatsLargeIntegersWithThousandSeparators()
+    {
+        var table = new TabularData(
+            ["Day", "RowCount"],
+            [
+                ["2026-02-27T00:00:00Z", "66380993"],
+                ["2026-02-28T00:00:00Z", "19639740"]
+            ]);
+
+        var rendered = Hex1bHumanRenderer.FormatDataTable(table, isQueryResultTable: true);
+
+        Assert.Contains("66,380,993", rendered, StringComparison.Ordinal);
+        Assert.Contains("19,639,740", rendered, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void FormatDataTable_QueryResults_StripsMidnightTimeFromDatetimes()
+    {
+        var table = new TabularData(
+            ["Day", "RowCount"],
+            [
+                ["2026-02-27T00:00:00Z", "100"],
+                ["2026-03-01T00:00:00Z", "200"]
+            ]);
+
+        var rendered = Hex1bHumanRenderer.FormatDataTable(table, isQueryResultTable: true);
+
+        Assert.Contains("2026-02-27", rendered, StringComparison.Ordinal);
+        Assert.Contains("2026-03-01", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain("T00:00:00Z", rendered, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void FormatDataTable_QueryResults_PreservesNonMidnightDatetimeWithReadableFormat()
+    {
+        var table = new TabularData(
+            ["Timestamp", "Value"],
+            [
+                ["2026-02-27T14:30:00Z", "42"]
+            ]);
+
+        var rendered = Hex1bHumanRenderer.FormatDataTable(table, isQueryResultTable: true);
+
+        Assert.Contains("2026-02-27 14:30:00Z", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain("T14:30:00Z", rendered, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void FormatDataTable_NonQueryTable_DoesNotFormatValues()
+    {
+        var table = new TabularData(
+            ["Name", "Count"],
+            [
+                ["DotnetEvents", "66380993"]
+            ]);
+
+        var rendered = Hex1bHumanRenderer.FormatDataTable(table, isQueryResultTable: false);
+
+        Assert.Contains("66380993", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain("66,380,993", rendered, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData(null, null)]
+    [InlineData("", "")]
+    [InlineData("hello", "hello")]
+    [InlineData("true", "true")]
+    [InlineData("false", "false")]
+    public void FormatCellValueForDisplay_NonNumericNonDatetime_ReturnsUnchanged(string? input, string? expected)
+    {
+        Assert.Equal(expected, Hex1bHumanRenderer.FormatCellValueForDisplay(input));
+    }
+
+    [Theory]
+    [InlineData("0", "0")]
+    [InlineData("42", "42")]
+    [InlineData("1000", "1,000")]
+    [InlineData("66380993", "66,380,993")]
+    [InlineData("-66380993", "-66,380,993")]
+    [InlineData("9999999999", "9,999,999,999")]
+    public void FormatCellValueForDisplay_Integers_FormatsWithThousandSeparators(string input, string expected)
+    {
+        Assert.Equal(expected, Hex1bHumanRenderer.FormatCellValueForDisplay(input));
+    }
+
+    [Theory]
+    [InlineData("1.5", "1.5")]
+    [InlineData("12345.67", "12,345.67")]
+    [InlineData("0.123", "0.123")]
+    [InlineData("-99999.99", "-99,999.99")]
+    public void FormatCellValueForDisplay_Decimals_FormatsWithThousandSeparators(string input, string expected)
+    {
+        Assert.Equal(expected, Hex1bHumanRenderer.FormatCellValueForDisplay(input));
+    }
+
+    [Theory]
+    [InlineData("001234", "001234")]
+    [InlineData("0123", "0123")]
+    [InlineData("00", "00")]
+    public void FormatCellValueForDisplay_LeadingZeroIntegers_ReturnsUnchanged(string input, string expected)
+    {
+        Assert.Equal(expected, Hex1bHumanRenderer.FormatCellValueForDisplay(input));
+    }
+
+    [Theory]
+    [InlineData("2026-02-27T00:00:00Z", "2026-02-27")]
+    [InlineData("2026-03-01T00:00:00Z", "2026-03-01")]
+    [InlineData("2026-02-27T00:00:00.0000000Z", "2026-02-27")]
+    public void FormatCellValueForDisplay_MidnightDatetime_ReturnsDateOnly(string input, string expected)
+    {
+        Assert.Equal(expected, Hex1bHumanRenderer.FormatCellValueForDisplay(input));
+    }
+
+    [Theory]
+    [InlineData("2026-02-27T14:30:00Z", "2026-02-27 14:30:00Z")]
+    [InlineData("2026-02-27T14:30:00.1234567Z", "2026-02-27 14:30:00.1234567Z")]
+    [InlineData("2026-02-27T14:30:00+05:00", "2026-02-27 14:30:00+05:00")]
+    public void FormatCellValueForDisplay_NonMidnightDatetime_ReplaceTWithSpace(string input, string expected)
+    {
+        Assert.Equal(expected, Hex1bHumanRenderer.FormatCellValueForDisplay(input));
+    }
+
+    [Theory]
+    [InlineData("1.23E+10")]
+    [InlineData("not-a-date")]
+    [InlineData("00:05:30")]
+    public void FormatCellValueForDisplay_UnrecognizedFormats_ReturnsUnchanged(string input)
+    {
+        Assert.Equal(input, Hex1bHumanRenderer.FormatCellValueForDisplay(input));
+    }
+
+    [Fact]
     public void RenderHyperlink_WithAnsi_EmitsOsc8Sequence()
     {
         var rendered = Hex1bHumanRenderer.RenderHyperlink("Open in Web Explorer", "https://example.com", useAnsi: true);

--- a/tests/Kusto.Cli.Tests/OutputFormatterTests.cs
+++ b/tests/Kusto.Cli.Tests/OutputFormatterTests.cs
@@ -411,4 +411,90 @@ public sealed class OutputFormatterTests
         Assert.Contains("```mermaid", rendered, StringComparison.Ordinal);
         Assert.Contains("pie showData", rendered, StringComparison.Ordinal);
     }
+
+    [Fact]
+    public void FormatHuman_QueryTableOutput_FormatsNumbersAndDatetimes()
+    {
+        var formatter = new OutputFormatter();
+        var output = new CliOutput
+        {
+            IsQueryResultTable = true,
+            Table = new TabularData(
+                ["Day", "RowCount"],
+                [
+                    ["2026-02-27T00:00:00Z", "66380993"],
+                    ["2026-02-28T00:00:00Z", "19639740"]
+                ])
+        };
+
+        var rendered = formatter.Format(output, OutputFormat.Human);
+
+        Assert.Contains("66,380,993", rendered, StringComparison.Ordinal);
+        Assert.Contains("19,639,740", rendered, StringComparison.Ordinal);
+        Assert.Contains("2026-02-27", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain("T00:00:00Z", rendered, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void FormatJson_QueryTableOutput_DoesNotFormatValues()
+    {
+        var formatter = new OutputFormatter();
+        var output = new CliOutput
+        {
+            IsQueryResultTable = true,
+            Table = new TabularData(
+                ["Day", "RowCount"],
+                [
+                    ["2026-02-27T00:00:00Z", "66380993"]
+                ])
+        };
+
+        var rendered = formatter.Format(output, OutputFormat.Json);
+
+        Assert.Contains("66380993", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain("66,380,993", rendered, StringComparison.Ordinal);
+        Assert.Contains("2026-02-27T00:00:00Z", rendered, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void FormatCsv_QueryTableOutput_DoesNotFormatValues()
+    {
+        var formatter = new OutputFormatter();
+        var output = new CliOutput
+        {
+            IsQueryResultTable = true,
+            Table = new TabularData(
+                ["Day", "RowCount"],
+                [
+                    ["2026-02-27T00:00:00Z", "66380993"]
+                ])
+        };
+
+        var rendered = formatter.Format(output, OutputFormat.Csv);
+
+        Assert.Contains("66380993", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain("66,380,993", rendered, StringComparison.Ordinal);
+        Assert.Contains("2026-02-27T00:00:00Z", rendered, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void FormatMarkdown_QueryTableOutput_DoesNotFormatValues()
+    {
+        var formatter = new OutputFormatter();
+        var output = new CliOutput
+        {
+            IsQueryResultTable = true,
+            Table = new TabularData(
+                ["Day", "RowCount"],
+                [
+                    ["2026-02-27T00:00:00Z", "66380993"]
+                ])
+        };
+
+        var rendered = formatter.Format(output, OutputFormat.Markdown);
+
+        Assert.Contains("66380993", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain("66,380,993", rendered, StringComparison.Ordinal);
+        Assert.Contains("2026-02-27T00:00:00Z", rendered, StringComparison.Ordinal);
+    }
 }


### PR DESCRIPTION
Applies human-friendly formatting to query result values in the \human\ output format:

- **Numbers**: Add thousand separators (e.g., \66380993\ → \66,380,993\)
- **Datetimes (midnight)**: Strip time element (e.g., \2026-02-27T00:00:00Z\ → \2026-02-27\)
- **Datetimes (non-midnight)**: Replace \T\ with space for readability (e.g., \2026-02-27T14:30:00Z\ → \2026-02-27 14:30:00Z\)
- **Zero-padded values**: Skipped to avoid misformatting identifiers (e.g., \