### PR TITLE
Add YAML output format support

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Grab the relevant executable asset from the latest [release](https://github.com/
 - Render compatible `render` results as terminal charts with `--chart`, or as Mermaid in markdown output
 - Show optional query execution statistics with `--show-stats`
 - Basic public, US Government, and China cloud support for token audience selection and Web Explorer links
-- Multiple output formats (`human`, `json`, `markdown`/`md`, plus query-only `csv`)
+- Multiple output formats (`human`, `json`, `yaml`, `markdown`/`md`, plus query-only `csv`)
 - Optional offline table data with TTL-based schema revalidation, per-table notes, and import/export support
 - Configurable log verbosity with structured console/file logging
 - GitHub Actions workflows for PR validation, versioned native release assets, and release promotion
@@ -63,6 +63,9 @@ kusto query --chart "StormEvents | summarize Count=count() by State | top 5 by C
 # Emit Mermaid markdown for a compatible render query
 kusto query --format markdown --chart "StormEvents | summarize Count=count() by State | top 5 by Count desc | render piechart"
 
+# Emit structured YAML for scripts/tools
+kusto database list --format yaml
+
 # Redirect query results directly to CSV
 kusto query "StormEvents | summarize EventCount = count() by State | top 10 by EventCount desc" --format csv > top-states.csv
 
@@ -89,7 +92,7 @@ $env:KUSTO_CONFIG_PATH = "C:\temp\kusto\config.json"
 
 - `human`: renders compatible chart types directly in the terminal after the tabular results
 - `markdown`: emits Mermaid chart syntax for compatible chart kinds after the markdown table
-- `json` / `csv`: rejected, because terminal/markdown chart rendering doesn't apply to JSON or CSV output
+- `json` / `yaml` / `csv`: rejected, because terminal/markdown chart rendering doesn't apply to JSON, YAML, or CSV output
 
 Supported render kinds:
 
@@ -214,7 +217,7 @@ These options are available on all commands:
 
 | Option | Values | Default | Description |
 |---|---|---|---|
-| `--format` | `human`, `json`, `markdown`, `md`, `csv` | `human` | Output format. `csv` is currently supported only for `query`. |
+| `--format` | `human`, `json`, `yaml`, `markdown`, `md`, `csv` | `human` | Output format. `csv` is currently supported only for `query`. |
 | `--log-level` | `Trace`, `Debug`, `Information`, `Warning`, `Error`, `Critical`, `None` | not set | Enables console logging at the selected level (logs are always written to file). |
 | `-h`, `--help` | n/a | n/a | Show help. |
 | `--version` | n/a | n/a | Show version. |
@@ -258,7 +261,7 @@ These options are available on all commands:
 | `--force` | destructive `table` / `table notes` actions | Skip the confirmation prompt when clearing or purging offline data. Alias: `-f`. |
 | `--use` | `cluster add` | Also set the added cluster as the active/default cluster. |
 | `--file <path>` | `query` | Read query text from file. Append `:<start>-<end>` to read an inclusive 1-based line range. Alias: `-f`. Cannot be combined with inline query argument. |
-| `--chart` | `query` | Render compatible query results as a chart for `human` or `markdown` output. Not supported with `json` or `csv`. |
+| `--chart` | `query` | Render compatible query results as a chart for `human` or `markdown` output. Not supported with `json`, `yaml`, or `csv`. |
 | `--show-stats` | `query` | Include query execution statistics when Kusto returns them. Not supported with `csv`. |
 
 ## Optional aliases
@@ -400,6 +403,9 @@ kusto table list --cluster help --database Samples --format human
 # JSON for scripts/tools
 kusto database list --cluster help --format json
 
+# YAML for structured output with readable nesting
+kusto database list --cluster help --format yaml
+
 # Markdown for docs/issues
 kusto query "StormEvents | take 3" --cluster help --database Samples --format markdown
 
@@ -407,7 +413,7 @@ kusto query "StormEvents | take 3" --cluster help --database Samples --format ma
 kusto query "StormEvents | summarize EventCount = count() by State | top 10 by EventCount desc" --cluster help --database Samples --format csv > top-states.csv
 ```
 
-Human and markdown output show a short `Open in Web Explorer` link when available instead of printing the raw `webExplorerUrl`; JSON output still includes `webExplorerUrl`, and `--show-stats` adds `statistics`. CSV output is query-only and writes just the tabular result data to stdout, so `--chart` and `--show-stats` are rejected with `--format csv`.
+Human and markdown output show a short `Open in Web Explorer` link when available instead of printing the raw `webExplorerUrl`; JSON and YAML output still include `webExplorerUrl`, and `--show-stats` adds `statistics`. CSV output is query-only and writes just the tabular result data to stdout, so `--chart` and `--show-stats` are rejected with `--format csv`.
 
 ## Logging
 

--- a/src/Kusto.Cli/CliRunner.cs
+++ b/src/Kusto.Cli/CliRunner.cs
@@ -8,6 +8,7 @@ public static class CliRunner
     [
         OutputFormat.Human,
         OutputFormat.Json,
+        OutputFormat.Yaml,
         OutputFormat.Markdown
     ];
 
@@ -15,6 +16,7 @@ public static class CliRunner
     [
         OutputFormat.Human,
         OutputFormat.Json,
+        OutputFormat.Yaml,
         OutputFormat.Markdown,
         OutputFormat.Csv
     ];
@@ -78,6 +80,7 @@ public static class CliRunner
         {
             "human" => OutputFormat.Human,
             "json" => OutputFormat.Json,
+            "yaml" => OutputFormat.Yaml,
             "markdown" => OutputFormat.Markdown,
             "md" => OutputFormat.Markdown,
             "csv" => OutputFormat.Csv,
@@ -162,6 +165,11 @@ public static class CliRunner
         if (uniqueFormats.Contains(OutputFormat.Json))
         {
             tokens.Add("json");
+        }
+
+        if (uniqueFormats.Contains(OutputFormat.Yaml))
+        {
+            tokens.Add("yaml");
         }
 
         if (uniqueFormats.Contains(OutputFormat.Markdown))

--- a/src/Kusto.Cli/CommandFactory.cs
+++ b/src/Kusto.Cli/CommandFactory.cs
@@ -8,11 +8,11 @@ public static class CommandFactory
     {
         var formatOption = new Option<string>("--format")
         {
-            Description = "Output format for people or tools: human, json, markdown, md, csv (query only).",
+            Description = "Output format for people or tools: human, json, yaml, markdown, md, csv (query only).",
             Recursive = true,
             DefaultValueFactory = _ => "human"
         };
-        formatOption.AcceptOnlyFromAmong("human", "json", "markdown", "md", "csv");
+        formatOption.AcceptOnlyFromAmong("human", "json", "yaml", "markdown", "md", "csv");
 
         var logLevelOption = new Option<string?>("--log-level")
         {
@@ -53,6 +53,7 @@ public static class CommandFactory
                             ["Browse", "kusto table list --cluster help --database Samples --filter \"^Storm\" --take 10"],
                             ["Browse", "kusto table show StormEvents --cluster help --database Samples"],
                             ["Run KQL", "kusto query \"StormEvents | take 5\" --cluster help --database Samples"],
+                            ["Run KQL", "kusto database list --cluster help --format yaml"],
                             ["Run KQL", "kusto query --chart \"StormEvents | summarize Count=count() by State | top 5 by Count desc | render columnchart\" --cluster help --database Samples"],
                             ["Run KQL", "kusto query --format markdown --chart \"StormEvents | summarize Count=count() by State | top 5 by Count desc | render piechart\" --cluster help --database Samples"],
                             ["Run KQL", "kusto query \"StormEvents | summarize EventCount=count() by State | top 10 by EventCount desc\" --format csv --cluster help --database Samples > top-states.csv"],
@@ -833,10 +834,11 @@ public static class CommandFactory
             return CliRunner.RunAsync(format, logLevel, async (runtime, ct) =>
             {
                 var isJsonOutput = string.Equals(format, "json", StringComparison.OrdinalIgnoreCase);
+                var isYamlOutput = string.Equals(format, "yaml", StringComparison.OrdinalIgnoreCase);
                 var isMarkdownOutput = string.Equals(format, "markdown", StringComparison.OrdinalIgnoreCase) ||
                     string.Equals(format, "md", StringComparison.OrdinalIgnoreCase);
                 var isCsvOutput = string.Equals(format, "csv", StringComparison.OrdinalIgnoreCase);
-                if (showChart && (isJsonOutput || isCsvOutput))
+                if (showChart && (isJsonOutput || isYamlOutput || isCsvOutput))
                 {
                     throw new UserFacingException($"--chart can't be used with --format {format.ToLowerInvariant()}.");
                 }
@@ -918,7 +920,7 @@ public static class CommandFactory
                     MarkdownChart = markdownChart,
                     IsQueryResultTable = true
                 };
-            }, cancellationToken, OutputFormat.Human, OutputFormat.Json, OutputFormat.Markdown, OutputFormat.Csv);
+            }, cancellationToken, OutputFormat.Human, OutputFormat.Json, OutputFormat.Yaml, OutputFormat.Markdown, OutputFormat.Csv);
         });
 
         return queryCommand;

--- a/src/Kusto.Cli/Contracts.cs
+++ b/src/Kusto.Cli/Contracts.cs
@@ -138,6 +138,7 @@ public enum OutputFormat
 {
     Human,
     Json,
+    Yaml,
     Markdown,
     Csv
 }

--- a/src/Kusto.Cli/OutputFormatter.cs
+++ b/src/Kusto.Cli/OutputFormatter.cs
@@ -11,10 +11,19 @@ public sealed class OutputFormatter : IOutputFormatter
         return format switch
         {
             OutputFormat.Json => JsonSerializer.Serialize(output, KustoJsonSerializerContext.Default.CliOutput),
+            OutputFormat.Yaml => FormatYaml(output),
             OutputFormat.Markdown => FormatMarkdown(output),
             OutputFormat.Csv => FormatCsv(output),
             _ => FormatHuman(output)
         };
+    }
+
+    private static string FormatYaml(CliOutput output)
+    {
+        var yaml = new StringBuilder();
+        var root = JsonSerializer.SerializeToElement(output, KustoJsonSerializerContext.Default.CliOutput);
+        AppendYamlValue(yaml, root, 0);
+        return yaml.ToString().TrimEnd();
     }
 
     private static string FormatHuman(CliOutput output)
@@ -278,6 +287,114 @@ public sealed class OutputFormatter : IOutputFormatter
         }
 
         return $"\"{text.Replace("\"", "\"\"", StringComparison.Ordinal)}\"";
+    }
+
+    private static void AppendYamlValue(StringBuilder buffer, JsonElement value, int indentLevel)
+    {
+        switch (value.ValueKind)
+        {
+            case JsonValueKind.Object:
+                AppendYamlObject(buffer, value, indentLevel);
+                break;
+            case JsonValueKind.Array:
+                AppendYamlArray(buffer, value, indentLevel);
+                break;
+            case JsonValueKind.String:
+                buffer.Append(FormatYamlString(value.GetString() ?? string.Empty));
+                break;
+            case JsonValueKind.Number:
+            case JsonValueKind.True:
+            case JsonValueKind.False:
+            case JsonValueKind.Null:
+                buffer.Append(value.GetRawText());
+                break;
+            default:
+                throw new InvalidOperationException($"Unsupported JSON value kind '{value.ValueKind}' for YAML formatting.");
+        }
+    }
+
+    private static void AppendYamlObject(StringBuilder buffer, JsonElement value, int indentLevel)
+    {
+        var properties = value.EnumerateObject().ToArray();
+        if (properties.Length == 0)
+        {
+            buffer.Append("{}");
+            return;
+        }
+
+        foreach (var property in properties)
+        {
+            AppendIndent(buffer, indentLevel);
+            buffer.Append(FormatYamlString(property.Name));
+            buffer.Append(':');
+
+            if (ShouldInlineYamlValue(property.Value))
+            {
+                buffer.Append(' ');
+                AppendYamlValue(buffer, property.Value, indentLevel);
+                buffer.AppendLine();
+                continue;
+            }
+
+            buffer.AppendLine();
+            AppendYamlValue(buffer, property.Value, indentLevel + 1);
+        }
+    }
+
+    private static void AppendYamlArray(StringBuilder buffer, JsonElement value, int indentLevel)
+    {
+        var itemCount = value.GetArrayLength();
+        if (itemCount == 0)
+        {
+            buffer.Append("[]");
+            return;
+        }
+
+        foreach (var item in value.EnumerateArray())
+        {
+            AppendIndent(buffer, indentLevel);
+            buffer.Append('-');
+
+            if (ShouldInlineYamlValue(item))
+            {
+                buffer.Append(' ');
+                AppendYamlValue(buffer, item, indentLevel);
+                buffer.AppendLine();
+                continue;
+            }
+
+            buffer.AppendLine();
+            AppendYamlValue(buffer, item, indentLevel + 1);
+        }
+    }
+
+    private static bool ShouldInlineYamlValue(JsonElement value)
+    {
+        return value.ValueKind switch
+        {
+            JsonValueKind.Object => !value.EnumerateObject().Any(),
+            JsonValueKind.Array => value.GetArrayLength() == 0,
+            _ => true
+        };
+    }
+
+    private static void AppendIndent(StringBuilder buffer, int indentLevel)
+    {
+        buffer.Append(' ', indentLevel * 2);
+    }
+
+    private static string FormatYamlString(string value)
+    {
+        var escaped = value
+            .Replace("\\", "\\\\", StringComparison.Ordinal)
+            .Replace("\"", "\\\"", StringComparison.Ordinal)
+            .Replace("\b", "\\b", StringComparison.Ordinal)
+            .Replace("\f", "\\f", StringComparison.Ordinal)
+            .Replace("\n", "\\n", StringComparison.Ordinal)
+            .Replace("\r", "\\r", StringComparison.Ordinal)
+            .Replace("\t", "\\t", StringComparison.Ordinal);
+
+        return $"\"{escaped}\"";
     }
 
     private static string BuildHumanTextOutput(CliOutput output, int? availableWidth)

--- a/tests/Kusto.Cli.Tests/OutputFormatterTests.cs
+++ b/tests/Kusto.Cli.Tests/OutputFormatterTests.cs
@@ -100,6 +100,41 @@ public sealed class OutputFormatterTests
     }
 
     [Fact]
+    public void FormatYaml_QueryOutput_IncludesWebExplorerUrlAndStatistics()
+    {
+        var formatter = new OutputFormatter();
+        var output = new CliOutput
+        {
+            Table = new TabularData(["Name"], [["alpha"]]),
+            WebExplorerUrl = "https://dataexplorer.azure.com/clusters/help.kusto.windows.net/databases/Samples?query=abc",
+            Statistics = new QueryStatistics
+            {
+                ExecutionTimeSec = 1.23,
+                Network = new QueryNetworkStatistics
+                {
+                    CrossClusterMb = 5.2
+                }
+            },
+            ChartHint = "not included",
+            HumanChart = "not included"
+        };
+
+        var rendered = formatter.Format(output, OutputFormat.Yaml);
+
+        Assert.Contains("\"message\": null", rendered, StringComparison.Ordinal);
+        Assert.Contains("\"table\":", rendered, StringComparison.Ordinal);
+        Assert.Contains("\"columns\":", rendered, StringComparison.Ordinal);
+        Assert.Contains("- \"Name\"", rendered, StringComparison.Ordinal);
+        Assert.Contains("\"properties\": null", rendered, StringComparison.Ordinal);
+        Assert.Contains("\"webExplorerUrl\": \"https://dataexplorer.azure.com/clusters/help.kusto.windows.net/databases/Samples?query=abc\"", rendered, StringComparison.Ordinal);
+        Assert.Contains("\"statistics\":", rendered, StringComparison.Ordinal);
+        Assert.Contains("\"executionTimeSec\": 1.23", rendered, StringComparison.Ordinal);
+        Assert.Contains("\"crossClusterMb\": 5.2", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain("\"chartHint\"", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain("\"humanChart\"", rendered, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void FormatCsv_TableOutput_UsesHeadersAndRows()
     {
         var formatter = new OutputFormatter();
@@ -343,6 +378,32 @@ public sealed class OutputFormatterTests
         Assert.Equal("State", document.RootElement.GetProperty("visualization").GetProperty("xColumn").GetString());
         Assert.Equal("Count", document.RootElement.GetProperty("visualization").GetProperty("yColumns")[0].GetString());
         Assert.Equal("{\"Visualization\":\"piechart\"}", document.RootElement.GetProperty("visualization").GetProperty("raw").GetString());
+    }
+
+    [Fact]
+    public void FormatYaml_QueryOutput_WithVisualization_IncludesStructuredMetadata()
+    {
+        var formatter = new OutputFormatter();
+        var output = new CliOutput
+        {
+            Table = new TabularData(["State"], [["TEXAS"]]),
+            Visualization = new QueryVisualization
+            {
+                Visualization = "piechart",
+                Title = "Top states",
+                XColumn = "State",
+                YColumns = ["Count"],
+                Raw = "{\"Visualization\":\"piechart\"}"
+            }
+        };
+
+        var rendered = formatter.Format(output, OutputFormat.Yaml);
+
+        Assert.Contains("\"visualization\":", rendered, StringComparison.Ordinal);
+        Assert.Contains("\"title\": \"Top states\"", rendered, StringComparison.Ordinal);
+        Assert.Contains("\"xColumn\": \"State\"", rendered, StringComparison.Ordinal);
+        Assert.Contains("- \"Count\"", rendered, StringComparison.Ordinal);
+        Assert.Contains("\"raw\": \"{\\\"Visualization\\\":\\\"piechart\\\"}\"", rendered, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/tests/Kusto.Cli.Tests/ParserTests.cs
+++ b/tests/Kusto.Cli.Tests/ParserTests.cs
@@ -21,6 +21,14 @@ public sealed class ParserTests
     }
 
     [Fact]
+    public void Parse_AllowsYamlFormat()
+    {
+        var rootCommand = CommandFactory.CreateRootCommand();
+        var result = rootCommand.Parse(["cluster", "list", "--format", "yaml"], new ParserConfiguration());
+        Assert.Empty(result.Errors);
+    }
+
+    [Fact]
     public void Parse_RejectsUnknownFormat()
     {
         var rootCommand = CommandFactory.CreateRootCommand();

--- a/tests/Kusto.Cli.Tests/QueryCommandTests.cs
+++ b/tests/Kusto.Cli.Tests/QueryCommandTests.cs
@@ -39,6 +39,28 @@ public sealed class QueryCommandTests
     }
 
     [Fact]
+    public async Task Query_WithYamlFormatAndChart_ReturnsError()
+    {
+        var rootCommand = CommandFactory.CreateRootCommand();
+        var originalError = Console.Error;
+        using var errorWriter = new StringWriter();
+        Console.SetError(errorWriter);
+
+        try
+        {
+            var exitCode = await rootCommand.Parse(["--format", "yaml", "query", "print 1", "--chart"], new ParserConfiguration())
+                .InvokeAsync();
+
+            Assert.Equal(1, exitCode);
+            Assert.Contains("--chart can't be used with --format yaml.", errorWriter.ToString(), StringComparison.Ordinal);
+        }
+        finally
+        {
+            Console.SetError(originalError);
+        }
+    }
+
+    [Fact]
     public async Task Query_WithCsvFormatAndShowStats_ReturnsError()
     {
         var rootCommand = CommandFactory.CreateRootCommand();


### PR DESCRIPTION
## Summary
- add yaml to the shared --format surface and query-specific format validation
- render YAML from the existing structured CliOutput shape so YAML mirrors JSON naming and metadata behavior
- cover YAML support with parser, formatter, query validation tests, and README updates

Closes #50