### PR TITLE
Add README JSON query example

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,9 @@ kusto query --format markdown --chart "StormEvents | summarize Count=count() by 
 # Emit machine-readable JSON for scripts or other automation
 kusto query "StormEvents | take 2" --format json
 
+# JSON output works on other commands too
+kusto database list --format json
+
 # Redirect query results directly to CSV
 kusto query "StormEvents | summarize EventCount = count() by State | top 10 by EventCount desc" --format csv > top-states.csv
 
@@ -73,7 +76,7 @@ kusto query "StormEvents | summarize EventCount = count() by State | top 10 by E
 kusto examples
 ```
 
-Use `--format json` when you want stable, machine-readable query output for scripts, automation, or downstream tools.
+Use `--format json` when you want stable, machine-readable output from queries or metadata commands for scripts, automation, or downstream tools.
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -63,12 +63,17 @@ kusto query --chart "StormEvents | summarize Count=count() by State | top 5 by C
 # Emit Mermaid markdown for a compatible render query
 kusto query --format markdown --chart "StormEvents | summarize Count=count() by State | top 5 by Count desc | render piechart"
 
+# Emit machine-readable JSON for scripts or other automation
+kusto query "StormEvents | take 2" --format json
+
 # Redirect query results directly to CSV
 kusto query "StormEvents | summarize EventCount = count() by State | top 10 by EventCount desc" --format csv > top-states.csv
 
 # Need copy/paste examples?
 kusto examples
 ```
+
+Use `--format json` when you want stable, machine-readable query output for scripts, automation, or downstream tools.
 
 ## Configuration
 


### PR DESCRIPTION
## Summary
- add a README quick-start example for kusto query --format json
- add a brief note on when JSON output is useful

Closes #52