### PR TITLE
Add chmod note for macOS/Linux install

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ irm https://kusto.damianedwards.dev/install.ps1 | iex
 ## Install on macOS or Linux
 
 Grab the relevant executable asset from the latest [release](https://github.com/DamianEdwards/kusto-cli/releases).
+After downloading it, you may need to run `chmod +x <asset>` before first use.
 
 ## What this CLI supports
 


### PR DESCRIPTION
## Summary
- add a short note in the macOS/Linux install section about running chmod +x on the downloaded executable

Closes #55