### PR TITLE
Preserve resource path for ADE/ADX proxy cluster URLs

### DIFF
--- a/src/Kusto.Cli/ClusterUtilities.cs
+++ b/src/Kusto.Cli/ClusterUtilities.cs
@@ -2,6 +2,71 @@ namespace Kusto.Cli;
 
 public static class ClusterUtilities
 {
+    // Fixed Kusto hostnames that front ADX as a proxy (ADE / AzureMonitor / Aria / security
+    // platform). Unlike classic ADX clusters (e.g., *.kusto.windows.net), a request to these
+    // hosts may carry a workspace- or resource-specific path that MUST be preserved end-to-end;
+    // collapsing to the bare hostname causes the proxy to reject the request
+    // (e.g., InvalidClusterHostName from prod-adxproxy).
+    //
+    // Source: the AllowedKustoHostnames entries in the public well-known Kusto endpoints list
+    // shipped with the official Azure Data Explorer SDKs (MIT). The list below is the union
+    // across all sovereign clouds. The azure-kusto-python copy is the superset authoritative
+    // reference today:
+    //   https://github.com/Azure/azure-kusto-python/blob/master/azure-kusto-data/azure/kusto/data/wellKnownKustoEndpoints.json
+    // Mirrored (and kept in sync) by azure-kusto-go:
+    //   https://github.com/Azure/azure-kusto-go/blob/master/azkustodata/trusted_endpoints/well_known_kusto_endpoints.json
+    private static readonly HashSet<string> ProxyHosts = new(StringComparer.OrdinalIgnoreCase)
+    {
+        // Public cloud (login.microsoftonline.com)
+        "ade.applicationinsights.io",
+        "ade.loganalytics.io",
+        "adx.aimon.applicationinsights.azure.com",
+        "adx.applicationinsights.azure.com",
+        "adx.int.applicationinsights.azure.com",
+        "adx.int.loganalytics.azure.com",
+        "adx.int.monitor.azure.com",
+        "adx.loganalytics.azure.com",
+        "adx.monitor.azure.com",
+        "kusto.aria.microsoft.com",
+        "eu.kusto.aria.microsoft.com",
+        "api.securityplatform.microsoft.com",
+
+        // US Government (Fairfax)
+        "adx.applicationinsights.azure.us",
+        "adx.loganalytics.azure.us",
+        "adx.monitor.azure.us",
+
+        // China (Mooncake)
+        "adx.applicationinsights.azure.cn",
+        "adx.loganalytics.azure.cn",
+        "adx.monitor.azure.cn",
+
+        // US Nat (EagleX)
+        "adx.applicationinsights.azure.eaglex.ic.gov",
+        "adx.loganalytics.azure.eaglex.ic.gov",
+        "adx.monitor.azure.eaglex.ic.gov",
+
+        // US Sec (scloud)
+        "adx.applicationinsights.azure.microsoft.scloud",
+        "adx.loganalytics.azure.microsoft.scloud",
+        "adx.monitor.azure.microsoft.scloud",
+
+        // France sovereign (Bleu)
+        "adx.applicationinsights.azure.fr",
+        "adx.loganalytics.azure.fr",
+        "adx.monitor.azure.fr",
+
+        // Germany sovereign (Delos)
+        "adx.applicationinsights.azure.de",
+        "adx.loganalytics.azure.de",
+        "adx.monitor.azure.de",
+
+        // Singapore sovereign (GovSG)
+        "adx.applicationinsights.azure.sg",
+        "adx.loganalytics.azure.sg",
+        "adx.monitor.azure.sg",
+    };
+
     public static string NormalizeClusterUrl(string clusterUrl)
     {
         if (!Uri.TryCreate(clusterUrl, UriKind.Absolute, out var uri) ||
@@ -10,8 +75,21 @@ public static class ClusterUtilities
             throw new UserFacingException($"'{clusterUrl}' is not a valid cluster URL.");
         }
 
+        if (IsProxyHost(uri.Host) && uri.AbsolutePath.Length > 1)
+        {
+            var builder = new UriBuilder(uri)
+            {
+                Query = string.Empty,
+                Fragment = string.Empty,
+            };
+
+            return builder.Uri.GetLeftPart(UriPartial.Path).TrimEnd('/');
+        }
+
         return uri.GetLeftPart(UriPartial.Authority).TrimEnd('/');
     }
+
+    public static bool IsProxyHost(string host) => ProxyHosts.Contains(host);
 
     public static KnownCluster? FindKnownCluster(KustoConfig config, string clusterReference)
     {

--- a/tests/Kusto.Cli.Tests/ClusterUtilitiesTests.cs
+++ b/tests/Kusto.Cli.Tests/ClusterUtilitiesTests.cs
@@ -1,0 +1,159 @@
+namespace Kusto.Cli.Tests;
+
+public sealed class ClusterUtilitiesTests
+{
+    [Theory]
+    [InlineData("https://help.kusto.windows.net", "https://help.kusto.windows.net")]
+    [InlineData("https://help.kusto.windows.net/", "https://help.kusto.windows.net")]
+    [InlineData("https://help.kusto.windows.net/Samples", "https://help.kusto.windows.net")]
+    [InlineData("HTTPS://Help.Kusto.Windows.Net", "https://help.kusto.windows.net")]
+    public void NormalizeClusterUrl_ClassicAdxHost_ReturnsAuthorityOnly(string input, string expected)
+    {
+        Assert.Equal(expected, ClusterUtilities.NormalizeClusterUrl(input));
+    }
+
+    [Theory]
+    [InlineData(
+        "https://ade.applicationinsights.io/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg/providers/Microsoft.OperationalInsights/workspaces/ws",
+        "https://ade.applicationinsights.io/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg/providers/Microsoft.OperationalInsights/workspaces/ws")]
+    [InlineData(
+        "https://ade.applicationinsights.io/subscriptions/sub/resourcegroups/rg/providers/Microsoft.OperationalInsights/workspaces/ws/",
+        "https://ade.applicationinsights.io/subscriptions/sub/resourcegroups/rg/providers/Microsoft.OperationalInsights/workspaces/ws")]
+    [InlineData(
+        "https://ade.loganalytics.io/subscriptions/sub/resourcegroups/rg/providers/Microsoft.OperationalInsights/workspaces/ws",
+        "https://ade.loganalytics.io/subscriptions/sub/resourcegroups/rg/providers/Microsoft.OperationalInsights/workspaces/ws")]
+    [InlineData(
+        "https://adx.applicationinsights.azure.com/subscriptions/sub/resourcegroups/rg/providers/microsoft.insights/components/app",
+        "https://adx.applicationinsights.azure.com/subscriptions/sub/resourcegroups/rg/providers/microsoft.insights/components/app")]
+    [InlineData(
+        "https://adx.monitor.azure.com/subscriptions/sub/resourcegroups/rg/providers/microsoft.insights/components/app",
+        "https://adx.monitor.azure.com/subscriptions/sub/resourcegroups/rg/providers/microsoft.insights/components/app")]
+    public void NormalizeClusterUrl_AdeProxyHost_PreservesResourcePath(string input, string expected)
+    {
+        Assert.Equal(expected, ClusterUtilities.NormalizeClusterUrl(input));
+    }
+
+    [Fact]
+    public void NormalizeClusterUrl_AdeProxyHost_StripsQueryAndFragment()
+    {
+        const string input = "https://ade.applicationinsights.io/subscriptions/sub/resourcegroups/rg/providers/Microsoft.OperationalInsights/workspaces/ws?foo=bar#frag";
+        const string expected = "https://ade.applicationinsights.io/subscriptions/sub/resourcegroups/rg/providers/Microsoft.OperationalInsights/workspaces/ws";
+
+        Assert.Equal(expected, ClusterUtilities.NormalizeClusterUrl(input));
+    }
+
+    [Fact]
+    public void NormalizeClusterUrl_AdeProxyHostWithoutPath_ReturnsAuthorityOnly()
+    {
+        Assert.Equal(
+            "https://ade.applicationinsights.io",
+            ClusterUtilities.NormalizeClusterUrl("https://ade.applicationinsights.io"));
+    }
+
+    [Fact]
+    public void NormalizeClusterUrl_InvalidUrl_Throws()
+    {
+        Assert.Throws<UserFacingException>(() => ClusterUtilities.NormalizeClusterUrl("not-a-url"));
+    }
+
+    [Theory]
+    [InlineData("ade.applicationinsights.io")]
+    [InlineData("ade.loganalytics.io")]
+    [InlineData("adx.aimon.applicationinsights.azure.com")]
+    [InlineData("adx.applicationinsights.azure.com")]
+    [InlineData("adx.int.applicationinsights.azure.com")]
+    [InlineData("adx.int.loganalytics.azure.com")]
+    [InlineData("adx.int.monitor.azure.com")]
+    [InlineData("adx.loganalytics.azure.com")]
+    [InlineData("adx.monitor.azure.com")]
+    [InlineData("kusto.aria.microsoft.com")]
+    [InlineData("eu.kusto.aria.microsoft.com")]
+    [InlineData("api.securityplatform.microsoft.com")]
+    [InlineData("adx.applicationinsights.azure.us")]
+    [InlineData("adx.loganalytics.azure.us")]
+    [InlineData("adx.monitor.azure.us")]
+    [InlineData("adx.applicationinsights.azure.cn")]
+    [InlineData("adx.loganalytics.azure.cn")]
+    [InlineData("adx.monitor.azure.cn")]
+    [InlineData("adx.applicationinsights.azure.eaglex.ic.gov")]
+    [InlineData("adx.loganalytics.azure.eaglex.ic.gov")]
+    [InlineData("adx.monitor.azure.eaglex.ic.gov")]
+    [InlineData("adx.applicationinsights.azure.microsoft.scloud")]
+    [InlineData("adx.loganalytics.azure.microsoft.scloud")]
+    [InlineData("adx.monitor.azure.microsoft.scloud")]
+    [InlineData("adx.applicationinsights.azure.fr")]
+    [InlineData("adx.loganalytics.azure.fr")]
+    [InlineData("adx.monitor.azure.fr")]
+    [InlineData("adx.applicationinsights.azure.de")]
+    [InlineData("adx.loganalytics.azure.de")]
+    [InlineData("adx.monitor.azure.de")]
+    [InlineData("adx.applicationinsights.azure.sg")]
+    [InlineData("adx.loganalytics.azure.sg")]
+    [InlineData("adx.monitor.azure.sg")]
+    public void NormalizeClusterUrl_AllKnownProxyHosts_PreservePath(string host)
+    {
+        var input = $"https://{host}/subscriptions/sub/resourcegroups/rg/providers/Microsoft.OperationalInsights/workspaces/ws";
+
+        Assert.Equal(input, ClusterUtilities.NormalizeClusterUrl(input));
+        Assert.True(ClusterUtilities.IsProxyHost(host));
+    }
+
+    [Fact]
+    public void IsProxyHost_IsCaseInsensitive()
+    {
+        Assert.True(ClusterUtilities.IsProxyHost("ADE.ApplicationInsights.IO"));
+    }
+
+    [Fact]
+    public void IsProxyHost_ReturnsFalseForClassicAdxCluster()
+    {
+        Assert.False(ClusterUtilities.IsProxyHost("help.kusto.windows.net"));
+    }
+
+    [Fact]
+    public void FindKnownCluster_MatchesAdeProxyUrlByNormalizedFullPath()
+    {
+        var config = new KustoConfig
+        {
+            Clusters =
+            [
+                new KnownCluster
+                {
+                    Name = "workspace-cluster",
+                    Url = "https://ade.applicationinsights.io/subscriptions/sub/resourcegroups/rg/providers/Microsoft.OperationalInsights/workspaces/ws",
+                }
+            ],
+        };
+
+        var match = ClusterUtilities.FindKnownCluster(
+            config,
+            "https://ade.applicationinsights.io/subscriptions/sub/resourcegroups/rg/providers/Microsoft.OperationalInsights/workspaces/ws/");
+
+        Assert.NotNull(match);
+        Assert.Equal("workspace-cluster", match!.Name);
+    }
+
+    [Fact]
+    public void NormalizeConfig_PreservesAdeProxyUrlsForSavedClustersAndDefaults()
+    {
+        const string adeUrl = "https://ade.applicationinsights.io/subscriptions/sub/resourcegroups/rg/providers/Microsoft.OperationalInsights/workspaces/ws";
+        var config = new KustoConfig
+        {
+            DefaultClusterUrl = adeUrl + "/",
+            Clusters =
+            [
+                new KnownCluster { Name = "ws", Url = adeUrl + "/" }
+            ],
+            DefaultDatabases = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                [adeUrl + "/"] = "ws",
+            },
+        };
+
+        var normalized = ClusterUtilities.NormalizeConfig(config);
+
+        Assert.Equal(adeUrl, normalized.DefaultClusterUrl);
+        Assert.Equal(adeUrl, normalized.Clusters[0].Url);
+        Assert.True(normalized.DefaultDatabases.ContainsKey(adeUrl));
+    }
+}

--- a/tests/Kusto.Cli.Tests/KustoHttpServiceTests.cs
+++ b/tests/Kusto.Cli.Tests/KustoHttpServiceTests.cs
@@ -522,6 +522,83 @@ public sealed class KustoHttpServiceTests
         Assert.Equal("'Sam'", propertiesElement.GetProperty("Parameters").GetProperty("filterValue").GetString());
     }
 
+    [Fact]
+    public async Task ExecuteQueryAsync_WithAdeProxyUrl_PreservesFullResourcePathInRequestUri()
+    {
+        const string responseJson =
+            """
+            [
+              { "FrameType": "DataSetHeader", "IsProgressive": false },
+              {
+                "FrameType": "DataTable",
+                "TableName": "PrimaryResult",
+                "TableKind": "PrimaryResult",
+                "Columns": [{ "ColumnName": "TimeGenerated", "ColumnType": "datetime" }],
+                "Rows": [["2026-01-01T00:00:00Z"]]
+              },
+              { "FrameType": "DataSetCompletion", "HasErrors": false }
+            ]
+            """;
+        var handler = new RecordingHandler(() => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(responseJson)
+        });
+        using var httpClient = new HttpClient(handler);
+        var service = new KustoHttpService(httpClient, new StaticTokenProvider("fake-token"), NullLogger<KustoHttpService>.Instance);
+
+        const string adeUrl = "https://ade.applicationinsights.io/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg/providers/Microsoft.OperationalInsights/workspaces/ws";
+
+        _ = await service.ExecuteQueryAsync(
+            adeUrl,
+            "ws",
+            "AppTraces | take 1",
+            includeStatistics: false,
+            CancellationToken.None);
+
+        Assert.NotNull(handler.LastRequestUri);
+        Assert.Equal(
+            adeUrl + "/v2/rest/query",
+            handler.LastRequestUri!.AbsoluteUri);
+    }
+
+    [Fact]
+    public async Task ExecuteManagementCommandAsync_WithAdeProxyUrl_PreservesFullResourcePathInRequestUri()
+    {
+        const string responseJson =
+            """
+            {
+              "Tables": [
+                {
+                  "TableName": "PrimaryResult",
+                  "TableKind": "PrimaryResult",
+                  "Columns": [{ "ColumnName": "TableName", "DataType": "string" }],
+                  "Rows": [["AppTraces"]]
+                }
+              ]
+            }
+            """;
+        var handler = new RecordingHandler(() => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(responseJson)
+        });
+        using var httpClient = new HttpClient(handler);
+        var service = new KustoHttpService(httpClient, new StaticTokenProvider("fake-token"), NullLogger<KustoHttpService>.Instance);
+
+        const string adeUrl = "https://adx.monitor.azure.com/subscriptions/sub/resourcegroups/rg/providers/microsoft.insights/components/app";
+
+        _ = await service.ExecuteManagementCommandAsync(
+            adeUrl,
+            "app",
+            ".show tables",
+            null,
+            CancellationToken.None);
+
+        Assert.NotNull(handler.LastRequestUri);
+        Assert.Equal(
+            adeUrl + "/v1/rest/mgmt",
+            handler.LastRequestUri!.AbsoluteUri);
+    }
+
     private sealed class StaticTokenProvider(string token) : ITokenProvider
     {
         public Task<string> GetTokenAsync(string clusterUrl, CancellationToken cancellationToken)
@@ -537,12 +614,14 @@ public sealed class KustoHttpServiceTests
         public string? LastAuthorizationScheme { get; private set; }
         public string? LastAuthorizationParameter { get; private set; }
         public string? LastRequestBody { get; private set; }
+        public Uri? LastRequestUri { get; private set; }
 
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
             LastAuthorizationScheme = request.Headers.Authorization?.Scheme;
             LastAuthorizationParameter = request.Headers.Authorization?.Parameter;
             LastRequestBody = request.Content is null ? null : await request.Content.ReadAsStringAsync(cancellationToken);
+            LastRequestUri = request.RequestUri;
             return _responseFactory();
         }
     }


### PR DESCRIPTION
## Summary

`kusto query --cluster <ade-proxy-url>` fails with `InvalidClusterHostName` when pointed at Application Insights / Log Analytics workspaces served by the ADE/ADX proxy (e.g. `https://ade.applicationinsights.io/subscriptions/.../workspaces/<ws>`). The error comes from `prod-adxproxy` because `ClusterUtilities.NormalizeClusterUrl` was collapsing the URL down to its authority via `GetLeftPart(UriPartial.Authority)`, stripping the workspace resource path before the request was issued. The adxproxy service does not whitelist the bare hostname, so the request is rejected.

## Fix

For a fixed allow-list of proxy hostnames (ADE/ADX proxies across all Azure sovereign clouds), preserve the full resource path instead of stripping it. All other hosts — classic ADX clusters such as `*.kusto.windows.net` — continue to normalize to authority-only, preserving existing behavior.

The hostname list is sourced from the authoritative public SDK endpoint lists:
- [azure-kusto-python `wellKnownKustoEndpoints.json`](https://github.com/Azure/azure-kusto-python/blob/master/azure-kusto-data/azure/kusto/data/wellKnownKustoEndpoints.json) (MIT)
- [azure-kusto-go `well_known_kusto_endpoints.json`](https://github.com/Azure/azure-kusto-go/blob/master/azkustodata/trusted_endpoints/well_known_kusto_endpoints.json) (MIT, mirror)

These are the `AllowedKustoHostnames` unioned across all sovereign cloud entries.

## Repro

```
kusto query "AppTraces | take 1" \
  --cluster "https://ade.applicationinsights.io/subscriptions/<sub>/resourcegroups/<rg>/providers/Microsoft.OperationalInsights/workspaces/<ws>" \
  --database "<ws>"
```

Before: `InvalidClusterHostName: Invalid host name ade.applicationinsights.io`
After: query executes against the full workspace path.

## Tests

- New `ClusterUtilitiesTests.cs` covering normalization behavior for proxy hosts (path preserved, query/fragment stripped, trailing slash trimmed) and regression coverage for classic ADX clusters (authority-only, unchanged).
- `KustoHttpServiceTests.cs` extended with `LastRequestUri` capture on the recording handler and two tests verifying the outgoing request URI retains the full resource path for both `ExecuteQueryAsync` and `ExecuteManagementCommandAsync`.
- Full suite: 214/214 pass.

## Acceptance criteria

- [x] `kusto query ... --cluster <full-ade-url>` routes to the full workspace path (unit-tested via outgoing request URI).
- [x] `kusto cluster add <full-ade-url>` round-trips with the resource path intact (covered in `ClusterUtilitiesTests`).
- [x] All proxy hostnames from the public SDK endpoint lists work equivalently.
- [x] Classic ADX clusters (e.g. `https://help.kusto.windows.net`) unchanged.
- [x] Regression test coverage included.
