### PR TITLE
Add TSV query output format

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Grab the relevant executable asset from the latest [release](https://github.com/
 - Render compatible `render` results as terminal charts with `--chart`, or as Mermaid in markdown output
 - Show optional query execution statistics with `--show-stats`
 - Basic public, US Government, and China cloud support for token audience selection and Web Explorer links
-- Multiple output formats (`human`, `json`, `markdown`/`md`, plus query-only `csv`)
+- Multiple output formats (`human`, `json`, `markdown`/`md`, plus query-only `csv` and `tsv`)
 - Optional offline table data with TTL-based schema revalidation, per-table notes, and import/export support
 - Configurable log verbosity with structured console/file logging
 - GitHub Actions workflows for PR validation, versioned native release assets, and release promotion
@@ -66,6 +66,9 @@ kusto query --format markdown --chart "StormEvents | summarize Count=count() by 
 # Redirect query results directly to CSV
 kusto query "StormEvents | summarize EventCount = count() by State | top 10 by EventCount desc" --format csv > top-states.csv
 
+# Or use TSV for tab-delimited export
+kusto query "StormEvents | summarize EventCount = count() by State | top 10 by EventCount desc" --format tsv > top-states.tsv
+
 # Need copy/paste examples?
 kusto examples
 ```
@@ -89,7 +92,7 @@ $env:KUSTO_CONFIG_PATH = "C:\temp\kusto\config.json"
 
 - `human`: renders compatible chart types directly in the terminal after the tabular results
 - `markdown`: emits Mermaid chart syntax for compatible chart kinds after the markdown table
-- `json` / `csv`: rejected, because terminal/markdown chart rendering doesn't apply to JSON or CSV output
+- `json` / `csv` / `tsv`: rejected, because terminal/markdown chart rendering doesn't apply to JSON or tabular export output
 
 Supported render kinds:
 
@@ -214,7 +217,7 @@ These options are available on all commands:
 
 | Option | Values | Default | Description |
 |---|---|---|---|
-| `--format` | `human`, `json`, `markdown`, `md`, `csv` | `human` | Output format. `csv` is currently supported only for `query`. |
+| `--format` | `human`, `json`, `markdown`, `md`, `csv`, `tsv` | `human` | Output format. `csv` and `tsv` are currently supported only for `query`. |
 | `--log-level` | `Trace`, `Debug`, `Information`, `Warning`, `Error`, `Critical`, `None` | not set | Enables console logging at the selected level (logs are always written to file). |
 | `-h`, `--help` | n/a | n/a | Show help. |
 | `--version` | n/a | n/a | Show version. |

--- a/src/Kusto.Cli/CliRunner.cs
+++ b/src/Kusto.Cli/CliRunner.cs
@@ -16,7 +16,8 @@ public static class CliRunner
         OutputFormat.Human,
         OutputFormat.Json,
         OutputFormat.Markdown,
-        OutputFormat.Csv
+        OutputFormat.Csv,
+        OutputFormat.Tsv
     ];
 
     public static Task<int> RunAsync(
@@ -81,6 +82,7 @@ public static class CliRunner
             "markdown" => OutputFormat.Markdown,
             "md" => OutputFormat.Markdown,
             "csv" => OutputFormat.Csv,
+            "tsv" => OutputFormat.Tsv,
             _ => throw new UserFacingException(
                 $"'{formatToken}' is not a valid output format. Use one of: {DescribeOutputFormats(RecognizedFormats)}.")
         };
@@ -173,6 +175,11 @@ public static class CliRunner
         if (uniqueFormats.Contains(OutputFormat.Csv))
         {
             tokens.Add("csv");
+        }
+
+        if (uniqueFormats.Contains(OutputFormat.Tsv))
+        {
+            tokens.Add("tsv");
         }
 
         return string.Join(", ", tokens);

--- a/src/Kusto.Cli/CommandFactory.cs
+++ b/src/Kusto.Cli/CommandFactory.cs
@@ -8,11 +8,11 @@ public static class CommandFactory
     {
         var formatOption = new Option<string>("--format")
         {
-            Description = "Output format for people or tools: human, json, markdown, md, csv (query only).",
+            Description = "Output format for people or tools: human, json, markdown, md, csv, tsv (csv/tsv are query only).",
             Recursive = true,
             DefaultValueFactory = _ => "human"
         };
-        formatOption.AcceptOnlyFromAmong("human", "json", "markdown", "md", "csv");
+        formatOption.AcceptOnlyFromAmong("human", "json", "markdown", "md", "csv", "tsv");
 
         var logLevelOption = new Option<string?>("--log-level")
         {
@@ -56,6 +56,7 @@ public static class CommandFactory
                             ["Run KQL", "kusto query --chart \"StormEvents | summarize Count=count() by State | top 5 by Count desc | render columnchart\" --cluster help --database Samples"],
                             ["Run KQL", "kusto query --format markdown --chart \"StormEvents | summarize Count=count() by State | top 5 by Count desc | render piechart\" --cluster help --database Samples"],
                             ["Run KQL", "kusto query \"StormEvents | summarize EventCount=count() by State | top 10 by EventCount desc\" --format csv --cluster help --database Samples > top-states.csv"],
+                            ["Run KQL", "kusto query \"StormEvents | summarize EventCount=count() by State | top 10 by EventCount desc\" --format tsv --cluster help --database Samples > top-states.tsv"],
                             ["Run KQL", "kusto query --file .\\queries\\top-states.kql --cluster help --database Samples"],
                             ["Optional aliases", "aliases | clusters | db | databases | tables | ls | get | schema | rm | delete | use | run | exec | --db | --limit | -f"]
                         ])
@@ -836,14 +837,16 @@ public static class CommandFactory
                 var isMarkdownOutput = string.Equals(format, "markdown", StringComparison.OrdinalIgnoreCase) ||
                     string.Equals(format, "md", StringComparison.OrdinalIgnoreCase);
                 var isCsvOutput = string.Equals(format, "csv", StringComparison.OrdinalIgnoreCase);
-                if (showChart && (isJsonOutput || isCsvOutput))
+                var isTsvOutput = string.Equals(format, "tsv", StringComparison.OrdinalIgnoreCase);
+                var isTabularExportOutput = isCsvOutput || isTsvOutput;
+                if (showChart && (isJsonOutput || isTabularExportOutput))
                 {
                     throw new UserFacingException($"--chart can't be used with --format {format.ToLowerInvariant()}.");
                 }
 
-                if (showStats && isCsvOutput)
+                if (showStats && isTabularExportOutput)
                 {
-                    throw new UserFacingException("--show-stats can't be used with --format csv.");
+                    throw new UserFacingException($"--show-stats can't be used with --format {format.ToLowerInvariant()}.");
                 }
 
                 var config = await runtime.ConfigStore.LoadAsync(ct);
@@ -899,7 +902,7 @@ public static class CommandFactory
                             }
                         }
                     }
-                    else if (!isMarkdownOutput && !isCsvOutput && compatibility.HumanChart is not null)
+                    else if (!isMarkdownOutput && !isTabularExportOutput && compatibility.HumanChart is not null)
                     {
                         chartHint = "This query can be rendered as a terminal chart. Re-run with --chart to see it.";
                     }
@@ -918,7 +921,7 @@ public static class CommandFactory
                     MarkdownChart = markdownChart,
                     IsQueryResultTable = true
                 };
-            }, cancellationToken, OutputFormat.Human, OutputFormat.Json, OutputFormat.Markdown, OutputFormat.Csv);
+            }, cancellationToken, OutputFormat.Human, OutputFormat.Json, OutputFormat.Markdown, OutputFormat.Csv, OutputFormat.Tsv);
         });
 
         return queryCommand;

--- a/src/Kusto.Cli/Contracts.cs
+++ b/src/Kusto.Cli/Contracts.cs
@@ -139,5 +139,6 @@ public enum OutputFormat
     Human,
     Json,
     Markdown,
-    Csv
+    Csv,
+    Tsv
 }

--- a/src/Kusto.Cli/OutputFormatter.cs
+++ b/src/Kusto.Cli/OutputFormatter.cs
@@ -13,6 +13,7 @@ public sealed class OutputFormatter : IOutputFormatter
             OutputFormat.Json => JsonSerializer.Serialize(output, KustoJsonSerializerContext.Default.CliOutput),
             OutputFormat.Markdown => FormatMarkdown(output),
             OutputFormat.Csv => FormatCsv(output),
+            OutputFormat.Tsv => FormatTsv(output),
             _ => FormatHuman(output)
         };
     }
@@ -122,6 +123,12 @@ public sealed class OutputFormatter : IOutputFormatter
     }
 
     private static string FormatCsv(CliOutput output)
+        => FormatDelimited(output, ',');
+
+    private static string FormatTsv(CliOutput output)
+        => FormatDelimited(output, '\t');
+
+    private static string FormatDelimited(CliOutput output, char delimiter)
     {
         if (output.Table is not { Columns.Count: > 0 } table)
         {
@@ -129,11 +136,11 @@ public sealed class OutputFormatter : IOutputFormatter
         }
 
         var buffer = new StringBuilder();
-        AppendCsvRow(buffer, table.Columns);
+        AppendDelimitedRow(buffer, table.Columns, delimiter);
 
         foreach (var row in table.Rows)
         {
-            AppendCsvRow(buffer, row);
+            AppendDelimitedRow(buffer, row, delimiter);
         }
 
         return buffer.ToString().TrimEnd('\r', '\n');
@@ -249,27 +256,27 @@ public sealed class OutputFormatter : IOutputFormatter
         }
     }
 
-    private static void AppendCsvRow(StringBuilder buffer, IEnumerable<string?> values)
+    private static void AppendDelimitedRow(StringBuilder buffer, IEnumerable<string?> values, char delimiter)
     {
         var firstValue = true;
         foreach (var value in values)
         {
             if (!firstValue)
             {
-                buffer.Append(',');
+                buffer.Append(delimiter);
             }
 
-            buffer.Append(EscapeCsvValue(value));
+            buffer.Append(EscapeDelimitedValue(value, delimiter));
             firstValue = false;
         }
 
         buffer.AppendLine();
     }
 
-    private static string EscapeCsvValue(string? value)
+    private static string EscapeDelimitedValue(string? value, char delimiter)
     {
         var text = value ?? string.Empty;
-        if (!text.Contains(',', StringComparison.Ordinal) &&
+        if (!text.Contains(delimiter) &&
             !text.Contains('"', StringComparison.Ordinal) &&
             !text.Contains('\r') &&
             !text.Contains('\n'))

--- a/tests/Kusto.Cli.Tests/OutputFormatterTests.cs
+++ b/tests/Kusto.Cli.Tests/OutputFormatterTests.cs
@@ -181,6 +181,87 @@ public sealed class OutputFormatterTests
     }
 
     [Fact]
+    public void FormatTsv_TableOutput_UsesHeadersAndRows()
+    {
+        var formatter = new OutputFormatter();
+        var output = new CliOutput
+        {
+            Table = new TabularData(
+                ["Name", "Count"],
+                [
+                    ["alpha", "42"],
+                    ["beta", "7"]
+                ])
+        };
+
+        var rendered = formatter.Format(output, OutputFormat.Tsv);
+
+        var expected = string.Join(Environment.NewLine, ["Name\tCount", "alpha\t42", "beta\t7"]);
+        Assert.Equal(expected, rendered);
+    }
+
+    [Fact]
+    public void FormatTsv_TableOutput_EscapesSpecialCharacters()
+    {
+        var formatter = new OutputFormatter();
+        var output = new CliOutput
+        {
+            Table = new TabularData(
+                ["Name", "Notes", "Quote"],
+                [
+                    ["alpha\tbeta", $"line1{Environment.NewLine}line2", "he said \"hi\""]
+                ])
+        };
+
+        var rendered = formatter.Format(output, OutputFormat.Tsv);
+
+        var expected = string.Join(
+            Environment.NewLine,
+            [
+                "Name\tNotes\tQuote",
+                $"\"alpha\tbeta\"\t\"line1{Environment.NewLine}line2\"\t\"he said \"\"hi\"\"\""
+            ]);
+        Assert.Equal(expected, rendered);
+    }
+
+    [Fact]
+    public void FormatTsv_QueryOutput_IgnoresNonTabularMetadata()
+    {
+        var formatter = new OutputFormatter();
+        var output = new CliOutput
+        {
+            Message = "not included",
+            Properties = new Dictionary<string, string?> { ["Name"] = "Samples" },
+            Table = new TabularData(["Name"], [["alpha"]]),
+            WebExplorerUrl = "https://dataexplorer.azure.com/",
+            Statistics = new QueryStatistics { ExecutionTimeSec = 1.23 },
+            Visualization = new QueryVisualization { Visualization = "piechart" },
+            ChartHint = "hint",
+            ChartMessage = "message",
+            HumanChart = "chart",
+            MarkdownChart = "```mermaid```"
+        };
+
+        var rendered = formatter.Format(output, OutputFormat.Tsv);
+
+        Assert.Equal(string.Join(Environment.NewLine, ["Name", "alpha"]), rendered);
+    }
+
+    [Fact]
+    public void FormatTsv_WithoutTable_ReturnsEmptyString()
+    {
+        var formatter = new OutputFormatter();
+        var output = new CliOutput
+        {
+            Message = "hello"
+        };
+
+        var rendered = formatter.Format(output, OutputFormat.Tsv);
+
+        Assert.Equal(string.Empty, rendered);
+    }
+
+    [Fact]
     public void FormatHuman_QueryOutput_HidesWebExplorerUrlByDefault()
     {
         var formatter = new OutputFormatter();

--- a/tests/Kusto.Cli.Tests/ParserTests.cs
+++ b/tests/Kusto.Cli.Tests/ParserTests.cs
@@ -21,6 +21,14 @@ public sealed class ParserTests
     }
 
     [Fact]
+    public void Parse_AllowsTsvFormat()
+    {
+        var rootCommand = CommandFactory.CreateRootCommand();
+        var result = rootCommand.Parse(["query", "print 1", "--format", "tsv"], new ParserConfiguration());
+        Assert.Empty(result.Errors);
+    }
+
+    [Fact]
     public void Parse_RejectsUnknownFormat()
     {
         var rootCommand = CommandFactory.CreateRootCommand();

--- a/tests/Kusto.Cli.Tests/QueryCommandTests.cs
+++ b/tests/Kusto.Cli.Tests/QueryCommandTests.cs
@@ -16,8 +16,10 @@ public sealed class QueryCommandTests
         Assert.Equal(1, exitCode);
     }
 
-    [Fact]
-    public async Task Query_WithCsvFormatAndChart_ReturnsError()
+    [Theory]
+    [InlineData("csv")]
+    [InlineData("tsv")]
+    public async Task Query_WithTabularFormatAndChart_ReturnsError(string format)
     {
         var rootCommand = CommandFactory.CreateRootCommand();
         var originalError = Console.Error;
@@ -26,11 +28,11 @@ public sealed class QueryCommandTests
 
         try
         {
-            var exitCode = await rootCommand.Parse(["--format", "csv", "query", "print 1", "--chart"], new ParserConfiguration())
+            var exitCode = await rootCommand.Parse(["--format", format, "query", "print 1", "--chart"], new ParserConfiguration())
                 .InvokeAsync();
 
             Assert.Equal(1, exitCode);
-            Assert.Contains("--chart can't be used with --format csv.", errorWriter.ToString(), StringComparison.Ordinal);
+            Assert.Contains($"--chart can't be used with --format {format}.", errorWriter.ToString(), StringComparison.Ordinal);
         }
         finally
         {
@@ -38,8 +40,10 @@ public sealed class QueryCommandTests
         }
     }
 
-    [Fact]
-    public async Task Query_WithCsvFormatAndShowStats_ReturnsError()
+    [Theory]
+    [InlineData("csv")]
+    [InlineData("tsv")]
+    public async Task Query_WithTabularFormatAndShowStats_ReturnsError(string format)
     {
         var rootCommand = CommandFactory.CreateRootCommand();
         var originalError = Console.Error;
@@ -48,11 +52,11 @@ public sealed class QueryCommandTests
 
         try
         {
-            var exitCode = await rootCommand.Parse(["--format", "csv", "query", "print 1", "--show-stats"], new ParserConfiguration())
+            var exitCode = await rootCommand.Parse(["--format", format, "query", "print 1", "--show-stats"], new ParserConfiguration())
                 .InvokeAsync();
 
             Assert.Equal(1, exitCode);
-            Assert.Contains("--show-stats can't be used with --format csv.", errorWriter.ToString(), StringComparison.Ordinal);
+            Assert.Contains($"--show-stats can't be used with --format {format}.", errorWriter.ToString(), StringComparison.Ordinal);
         }
         finally
         {
@@ -60,8 +64,10 @@ public sealed class QueryCommandTests
         }
     }
 
-    [Fact]
-    public async Task ClusterList_WithCsvFormat_ReturnsError()
+    [Theory]
+    [InlineData("csv")]
+    [InlineData("tsv")]
+    public async Task ClusterList_WithTabularFormat_ReturnsError(string format)
     {
         var rootCommand = CommandFactory.CreateRootCommand();
         var originalError = Console.Error;
@@ -70,11 +76,11 @@ public sealed class QueryCommandTests
 
         try
         {
-            var exitCode = await rootCommand.Parse(["cluster", "list", "--format", "csv"], new ParserConfiguration())
+            var exitCode = await rootCommand.Parse(["cluster", "list", "--format", format], new ParserConfiguration())
                 .InvokeAsync();
 
             Assert.Equal(1, exitCode);
-            Assert.Contains("'csv' is not supported for this command.", errorWriter.ToString(), StringComparison.Ordinal);
+            Assert.Contains($"'{format}' is not supported for this command.", errorWriter.ToString(), StringComparison.Ordinal);
         }
         finally
         {


### PR DESCRIPTION
## Summary
- add TSV as a new query-only output format alongside CSV
- share delimited rendering logic for CSV and TSV output
- document TSV usage and cover it with parser, formatter, and query tests

Closes #50