### PR TITLE
Option to produce the rasterized image for LLMs to effectively navigate temporal data

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,6 +171,14 @@ jobs:
         shell: pwsh
         run: ./scripts/Publish-NativeAsset.ps1 -RuntimeIdentifier '${{ matrix.rid }}' -Version '${{ needs.version.outputs.version }}' -ArtifactsDirectory './artifacts/dev'
 
+      - name: Smoke-test packaged archive
+        # Skip cross-arch smoke tests: GitHub-hosted runners can't execute
+        # win-arm64 / linux-arm64 binaries on x64 runners, and the *-arm64
+        # AOT publish above already validated the archive shape.
+        if: ${{ !endsWith(matrix.rid, '-arm64') }}
+        shell: pwsh
+        run: ./scripts/Test-PackagedArchive.ps1 -RuntimeIdentifier '${{ matrix.rid }}' -Version '${{ needs.version.outputs.version }}' -ArtifactsDirectory './artifacts/dev' -SkipPublish
+
       - name: Upload dev artifact
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
         with:
@@ -226,6 +234,11 @@ jobs:
       - name: Publish native asset
         shell: pwsh
         run: ./scripts/Publish-NativeAsset.ps1 -RuntimeIdentifier '${{ matrix.rid }}' -Version '${{ needs.version.outputs.rc_version }}' -ArtifactsDirectory './artifacts/rc'
+
+      - name: Smoke-test packaged archive
+        if: ${{ !endsWith(matrix.rid, '-arm64') }}
+        shell: pwsh
+        run: ./scripts/Test-PackagedArchive.ps1 -RuntimeIdentifier '${{ matrix.rid }}' -Version '${{ needs.version.outputs.rc_version }}' -ArtifactsDirectory './artifacts/rc' -SkipPublish
 
       - name: Upload RC artifact
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -186,7 +186,10 @@ jobs:
           signing-account-name: ${{ secrets.AZURE_SIGNING_ACCOUNT }}
           certificate-profile-name: ${{ secrets.AZURE_CERT_PROFILE }}
           files-folder: ${{ github.workspace }}\artifacts\windows-assets
-          files-folder-filter: kusto.exe
+          # Sign every executable payload file we ship: kusto.exe and the native
+          # SkiaSharp/HarfBuzz sidecars. A signed kusto.exe loading unsigned
+          # native DLLs at first chart render would defeat the trust chain.
+          files-folder-filter: kusto.exe,libSkiaSharp.dll,libHarfBuzzSharp.dll
           files-folder-recurse: true
           file-digest: SHA256
           timestamp-rfc3161: http://timestamp.acs.microsoft.com
@@ -205,13 +208,18 @@ jobs:
       - name: Verify signed Windows issuer
         shell: pwsh
         run: |
-          $binaryPaths = @(Get-ChildItem -Path './artifacts/windows-assets' -Recurse -Filter 'kusto.exe' -File)
-          if ($binaryPaths.Count -eq 0) {
-            throw "No signed kusto.exe files were found under './artifacts/windows-assets'."
+          # Each archive expansion is its own subdirectory under ./artifacts/windows-assets.
+          # Verify the trust chain on every executable payload file (kusto.exe + native
+          # sidecars) listed in the installer trust configuration so a missing or
+          # unsigned sidecar causes the release to fail loudly here, not in the field.
+          $payloadRoots = @(Get-ChildItem -Path './artifacts/windows-assets' -Directory)
+          if ($payloadRoots.Count -eq 0) {
+            # Single flat layout — verify the root directly.
+            $payloadRoots = @([pscustomobject]@{ FullName = (Resolve-Path './artifacts/windows-assets').Path })
           }
 
-          foreach ($binaryPath in $binaryPaths) {
-            ./scripts/Verify-WindowsBinaryIssuer.ps1 -BinaryPath $binaryPath.FullName -InstallerScriptPath './scripts/install/install-kusto-cli.ps1'
+          foreach ($payloadRoot in $payloadRoots) {
+            ./scripts/Verify-WindowsBinaryIssuer.ps1 -PayloadDirectory $payloadRoot.FullName -InstallerScriptPath './scripts/install/install-kusto-cli.ps1'
           }
 
       - name: Repack signed Windows assets

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ artifacts/
 *.log
 *.tmp
 *.temp
+
+# Local chart renders
+*.png

--- a/.gitignore
+++ b/.gitignore
@@ -20,4 +20,7 @@ artifacts/
 *.temp
 
 # Local chart renders
-*.png
+/chart.png
+/cpu.png
+/top-states.png
+/pie.png

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Grab the relevant executable asset from the latest [release](https://github.com/
 - Show copy/paste-ready examples and aliases (`examples`)
 - Include Azure Data Explorer Web Explorer deeplinks in query results
 - Surface Kusto `render` metadata in query results when visualization annotations are returned
-- Render compatible `render` results as terminal charts with `--chart`, or as Mermaid in markdown output
+- Render compatible `render` results as terminal charts with `--chart`, as Mermaid in markdown output, or as PNG images via `--output-chart`
 - Show optional query execution statistics with `--show-stats`
 - Basic public, US Government, and China cloud support for token audience selection and Web Explorer links
 - Multiple output formats (`human`, `json`, `markdown`/`md`, plus query-only `csv`)
@@ -60,6 +60,9 @@ kusto query "StormEvents | take 5"
 # Render a compatible chart directly in the terminal
 kusto query --chart "StormEvents | summarize Count=count() by State | top 5 by Count desc | render columnchart"
 
+# Save the chart as a PNG image
+kusto query --output-chart ./top-states.png "StormEvents | summarize Count=count() by State | top 5 by Count desc | render columnchart"
+
 # Emit Mermaid markdown for a compatible render query
 kusto query --format markdown --chart "StormEvents | summarize Count=count() by State | top 5 by Count desc | render piechart"
 
@@ -93,19 +96,48 @@ $env:KUSTO_CONFIG_PATH = "C:\temp\kusto\config.json"
 
 Supported render kinds:
 
-| Kusto `render` kind | `human --chart` | `markdown --chart` | Notes |
-|---|---|---|---|
-| `columnchart` | yes | yes | Human output renders a terminal column chart; markdown emits Mermaid `xychart`. |
-| `barchart` | yes | yes | Human output renders a terminal bar chart; markdown emits Mermaid `xychart horizontal`. |
-| `linechart` | yes | yes | Human output renders a terminal line chart; markdown emits Mermaid `xychart`. |
-| `timechart` | yes | yes | Alias of `linechart`. |
-| `piechart` | yes | yes | Human output renders a terminal pie chart with a legend; markdown emits Mermaid `pie`. |
+| Kusto `render` kind | `human --chart` | `markdown --chart` | `--output-chart` (PNG) | Notes |
+|---|---|---|---|---|
+| `columnchart` | yes | yes | yes | Human output renders a terminal column chart; markdown emits Mermaid `xychart`; PNG draws via ScottPlot. |
+| `barchart` | yes | yes | yes | Human output renders a terminal bar chart; markdown emits Mermaid `xychart horizontal`; PNG draws via ScottPlot. |
+| `linechart` | yes | yes | yes | Human output renders a terminal line chart; markdown emits Mermaid `xychart`; PNG draws via ScottPlot. |
+| `timechart` | yes | yes | yes | Alias of `linechart`. |
+| `piechart` | yes | yes | yes | Human output renders a terminal pie chart with a legend; markdown emits Mermaid `pie`; PNG draws a pie with a value/percentage legend. |
 
 Layout support:
 
-- `linechart` and `timechart` support `default`/`unstacked`, `stacked`, and `stacked100` for terminal rendering
-- `columnchart` and `barchart` support `default`/`unstacked`, `grouped`, `stacked`, and `stacked100` for terminal rendering
+- `linechart` and `timechart` support `default`/`unstacked`, `stacked`, and `stacked100` for terminal and PNG rendering
+- `columnchart` and `barchart` support `default`/`unstacked`, `grouped`, `stacked`, and `stacked100` for terminal and PNG rendering
 - Mermaid cartesian output currently requires the simple/default layout and exactly one series
+
+### Image output (PNG)
+
+`--output-chart <path.png>` writes the rendered chart to a PNG file using [ScottPlot](https://scottplot.net/) (Apache 2.0, headless SkiaSharp backend). It is orthogonal to `--chart`: the file is always written when supplied and works alongside any `--format`, including `json` and `csv`. Raw tabular data is suppressed from output when `--output-chart` is set — only the chart path confirmation line (and any stats/visualization metadata) is emitted. Use it when you want a chart that's readable by image viewers, embeddable in docs, or consumable by multimodal LLMs.
+
+```powershell
+# Save a PNG alongside human terminal output
+kusto query --chart --output-chart ./top-states.png "StormEvents | summarize Count=count() by State | top 5 by Count desc | render columnchart"
+
+# Save a PNG while emitting CSV to stdout
+kusto query --format csv --output-chart ./top-states.png "StormEvents | summarize Count=count() by State | top 5 by Count desc | render columnchart" > top-states.csv
+
+# Custom dimensions
+kusto query --output-chart ./pie.png --output-chart-width 1600 --output-chart-height 900 "StormEvents | summarize Count=count() by State | top 5 by Count desc | render piechart"
+```
+
+Image-output options:
+
+| Option | Default | Notes |
+|---|---|---|
+| `--output-chart <path>` | _(off)_ | Path must end in `.png`. Parent directories are created if missing. |
+| `--output-chart-width <pixels>` | `1200` | Range 200..8192. Requires `--output-chart`. |
+| `--output-chart-height <pixels>` | `675` | Range 200..8192. Requires `--output-chart`. |
+
+Behavior notes:
+
+- The image renderer consumes the same compatibility analysis as the terminal renderer, so any chart kind/layout that renders in the terminal will render to PNG.
+- The PNG palette is a neutral, high-contrast set (white background, dark axes/text, saturated, well-separated series colors) chosen for legibility under OCR and multimodal LLM ingestion rather than to match the Hex1b terminal palette pixel-for-pixel.
+- If the query has no `render` annotation or the kind is unsupported, `--output-chart` fails with the same reason `--chart` would have surfaced.
 
 Example terminal renderings captured as plain text:
 
@@ -236,7 +268,7 @@ These options are available on all commands:
 | `table list` | List tables in a database. | none | `--cluster`, `--database`, `--filter`, `--take`, global options |
 | `table show <table>` | Show table details, column schema, docstrings, and stored notes. | `table` | `--cluster`, `--database`, `--refresh-offline-data`, global options |
 | `table notes [<table>]` | List, add, delete, or clear table notes. | optional `table` | `--cluster`, `--database`, `--add`, `--id`, `--delete`, `--clear`, `--force`, global options |
-| `query [<query>]` | Run KQL from inline text, file, or stdin. | optional `query` | `--file`, `--cluster`, `--database`, `--chart`, `--show-stats`, global options |
+| `query [<query>]` | Run KQL from inline text, file, or stdin. | optional `query` | `--file`, `--cluster`, `--database`, `--chart`, `--output-chart`, `--output-chart-width`, `--output-chart-height`, `--show-stats`, global options |
 
 ## Command-specific option details
 
@@ -259,6 +291,9 @@ These options are available on all commands:
 | `--use` | `cluster add` | Also set the added cluster as the active/default cluster. |
 | `--file <path>` | `query` | Read query text from file. Append `:<start>-<end>` to read an inclusive 1-based line range. Alias: `-f`. Cannot be combined with inline query argument. |
 | `--chart` | `query` | Render compatible query results as a chart for `human` or `markdown` output. Not supported with `json` or `csv`. |
+| `--output-chart <path>` | `query` | Write the rendered chart as a PNG to the given path. Works with any `--format`, including `json` and `csv`. Suppresses raw data output. Path must end in `.png`. Parent directories are created automatically. |
+| `--output-chart-width <pixels>` | `query` | PNG width in pixels for `--output-chart`. Default: `1200`. Range: 200–8192. Requires `--output-chart`. |
+| `--output-chart-height <pixels>` | `query` | PNG height in pixels for `--output-chart`. Default: `675`. Range: 200–8192. Requires `--output-chart`. |
 | `--show-stats` | `query` | Include query execution statistics when Kusto returns them. Not supported with `csv`. |
 
 ## Optional aliases
@@ -389,6 +424,21 @@ kusto query "StormEvents | summarize Count=count() by bin(StartTime, 1d) | rende
 
 # Emit Mermaid pie chart output in markdown
 kusto query "StormEvents | summarize Count=count() by State | top 5 by Count desc | render piechart" --cluster help --database Samples --format markdown --chart
+
+# Save a column chart as a PNG (default 1200×675)
+kusto query "StormEvents | summarize Count=count() by State | top 5 by Count desc | render columnchart" --cluster help --database Samples --output-chart ./top-states.png
+
+# Save a PNG and render in the terminal at the same time
+kusto query "StormEvents | summarize Count=count() by State | top 5 by Count desc | render columnchart" --cluster help --database Samples --chart --output-chart ./top-states.png
+
+# Save a PNG at a custom size
+kusto query "StormEvents | summarize Count=count() by State | top 5 by Count desc | render piechart" --cluster help --database Samples --output-chart ./pie.png --output-chart-width 1600 --output-chart-height 900
+
+# Save a PNG while still streaming results as CSV
+kusto query "StormEvents | summarize Count=count() by State | top 5 by Count desc | render columnchart" --cluster help --database Samples --format csv --output-chart ./top-states.png > top-states.csv
+
+# Save a PNG while capturing results as JSON (chartOutputPath appears in the envelope)
+kusto query "StormEvents | summarize Count=count() by State | top 5 by Count desc | render columnchart" --cluster help --database Samples --format json --output-chart ./top-states.png
 ```
 
 ## Output formats
@@ -605,3 +655,4 @@ dotnet publish ./src/Kusto.Cli/ --os linux [--arch <arch>]
 ## License
 
 MIT
+

--- a/README.md
+++ b/README.md
@@ -112,7 +112,9 @@ Layout support:
 
 ### Image output (PNG)
 
-`--output-chart <path.png>` writes the rendered chart to a PNG file using [ScottPlot](https://scottplot.net/) (Apache 2.0, headless SkiaSharp backend). It is orthogonal to `--chart`: the file is always written when supplied and works alongside any `--format`, including `json` and `csv`. Raw tabular data is suppressed from output when `--output-chart` is set — only the chart path confirmation line (and any stats/visualization metadata) is emitted. Use it when you want a chart that's readable by image viewers, embeddable in docs, or consumable by multimodal LLMs.
+`--output-chart <path.png>` writes the rendered chart to a PNG file using [ScottPlot](https://scottplot.net/) (MIT, headless SkiaSharp backend). It is orthogonal to `--chart`: the file is always written when supplied and works alongside any `--format`, including `json` and `csv`. For display formats (`human`, `markdown`, `json`) the raw tabular data is suppressed and only a chart-written confirmation (plus any stats/visualization metadata) is emitted. For `--format csv` the CSV stream is preserved on stdout so `... --format csv --output-chart x.png > data.csv` writes both the PNG (as a side effect) and the CSV data; the chart-written confirmation goes to stderr in that case. Use it when you want a chart that's readable by image viewers, embeddable in docs, or consumable by multimodal LLMs.
+
+Third-party licenses for the rendering stack are summarized in [THIRD-PARTY-NOTICES.md](./THIRD-PARTY-NOTICES.md).
 
 ```powershell
 # Save a PNG alongside human terminal output
@@ -291,7 +293,7 @@ These options are available on all commands:
 | `--use` | `cluster add` | Also set the added cluster as the active/default cluster. |
 | `--file <path>` | `query` | Read query text from file. Append `:<start>-<end>` to read an inclusive 1-based line range. Alias: `-f`. Cannot be combined with inline query argument. |
 | `--chart` | `query` | Render compatible query results as a chart for `human` or `markdown` output. Not supported with `json` or `csv`. |
-| `--output-chart <path>` | `query` | Write the rendered chart as a PNG to the given path. Works with any `--format`, including `json` and `csv`. Suppresses raw data output. Path must end in `.png`. Parent directories are created automatically. |
+| `--output-chart <path>` | `query` | Write the rendered chart as a PNG to the given path. Works with any `--format`. For `human`/`markdown`/`json` the raw tabular data is suppressed and a chart-written confirmation is emitted on stdout. For `csv` the CSV stream stays on stdout and the chart-written confirmation goes to stderr. Path must end in `.png`. Parent directories are created automatically. |
 | `--output-chart-width <pixels>` | `query` | PNG width in pixels for `--output-chart`. Default: `1200`. Range: 200–8192. Requires `--output-chart`. |
 | `--output-chart-height <pixels>` | `query` | PNG height in pixels for `--output-chart`. Default: `675`. Range: 200–8192. Requires `--output-chart`. |
 | `--show-stats` | `query` | Include query execution statistics when Kusto returns them. Not supported with `csv`. |

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ kusto cluster add help https://help.kusto.windows.net/
 kusto cluster add help https://help.kusto.windows.net/ --use
 
 # 2) Set default database for that cluster
-kusto database set-default Samples --cluster help
+kusto database set-default Samples --cluster https://help.kusto.windows.net
 
 # 3) Run a query
 kusto query "StormEvents | take 5"
@@ -356,43 +356,43 @@ kusto cluster remove help
 kusto database list
 
 # List using explicit cluster and filter/take
-kusto database list --cluster help --filter "^Sam" --take 5
-kusto database list --cluster help --filter "ples$"
+kusto database list --cluster https://help.kusto.windows.net --filter "^Sam" --take 5
+kusto database list --cluster https://help.kusto.windows.net --filter "ples$"
 
 # Show one database
-kusto database show Samples --cluster help
+kusto database show Samples --cluster https://help.kusto.windows.net
 
 # Set default DB for a cluster
-kusto database set-default Samples --cluster help
+kusto database set-default Samples --cluster https://help.kusto.windows.net
 ```
 
 ### Table commands
 
 ```powershell
 # List tables using default DB for selected/default cluster
-kusto table list --cluster help --database Samples
+kusto table list --cluster https://help.kusto.windows.net --database Samples
 
 # Filtered table listing
-kusto table list --cluster help --database Samples --filter "^Storm" --take 10
+kusto table list --cluster https://help.kusto.windows.net --database Samples --filter "^Storm" --take 10
 
 # Show a specific table schema/details
-kusto table show StormEvents --cluster help --database Samples
+kusto table show StormEvents --cluster https://help.kusto.windows.net --database Samples
 
 # Force a live refresh of the cached table details
-kusto table show StormEvents --cluster help --database Samples --refresh-offline-data
+kusto table show StormEvents --cluster https://help.kusto.windows.net --database Samples --refresh-offline-data
 
 # Add and inspect table notes
-kusto table notes StormEvents --cluster help --database Samples --add "Use this table for weather samples."
-kusto table notes StormEvents --cluster help --database Samples
+kusto table notes StormEvents --cluster https://help.kusto.windows.net --database Samples --add "Use this table for weather samples."
+kusto table notes StormEvents --cluster https://help.kusto.windows.net --database Samples
 
 # Delete a specific note or clear notes
-kusto table notes StormEvents --cluster help --database Samples --delete 1
+kusto table notes StormEvents --cluster https://help.kusto.windows.net --database Samples --delete 1
 kusto table notes --clear --force
 
 # Export/import or clear offline data
 kusto table --export-offline-data .\offline-table-data.json
 kusto table --import-offline-data .\offline-table-data.json
-kusto table StormEvents --cluster help --database Samples --clear-offline-data --force
+kusto table StormEvents --cluster https://help.kusto.windows.net --database Samples --clear-offline-data --force
 kusto table --purge-offline-data --force
 ```
 
@@ -400,63 +400,63 @@ kusto table --purge-offline-data --force
 
 ```powershell
 # Inline query
-kusto query "StormEvents | summarize Count=count() by State | top 10 by Count desc" --cluster help --database Samples
+kusto query "StormEvents | summarize Count=count() by State | top 10 by Count desc" --cluster https://help.kusto.windows.net --database Samples
 
 # Query from file
-kusto query --file .\queries\top-states.kql --cluster help --database Samples
+kusto query --file .\queries\top-states.kql --cluster https://help.kusto.windows.net --database Samples
 
 # Query a specific line range from a file containing multiple statements
-kusto query --file .\queries\top-states.kql:12-15 --cluster help --database Samples
+kusto query --file .\queries\top-states.kql:12-15 --cluster https://help.kusto.windows.net --database Samples
 
 # Query from stdin
 @"
 StormEvents
 | where StartTime > ago(7d)
 | take 20
-"@ | kusto query - --cluster help --database Samples
+"@ | kusto query - --cluster https://help.kusto.windows.net --database Samples
 
 # Query with execution statistics when available
-kusto query "StormEvents | summarize Count=count() by State" --cluster help --database Samples --show-stats
+kusto query "StormEvents | summarize Count=count() by State" --cluster https://help.kusto.windows.net --database Samples --show-stats
 
 # Render a terminal bar chart
-kusto query "StormEvents | summarize Count=count() by State | top 5 by Count desc | render barchart" --cluster help --database Samples --chart
+kusto query "StormEvents | summarize Count=count() by State | top 5 by Count desc | render barchart" --cluster https://help.kusto.windows.net --database Samples --chart
 
 # Render a terminal time series chart (`timechart` is an alias of `linechart`)
-kusto query "StormEvents | summarize Count=count() by bin(StartTime, 1d) | render timechart" --cluster help --database Samples --chart
+kusto query "StormEvents | summarize Count=count() by bin(StartTime, 1d) | render timechart" --cluster https://help.kusto.windows.net --database Samples --chart
 
 # Emit Mermaid pie chart output in markdown
-kusto query "StormEvents | summarize Count=count() by State | top 5 by Count desc | render piechart" --cluster help --database Samples --format markdown --chart
+kusto query "StormEvents | summarize Count=count() by State | top 5 by Count desc | render piechart" --cluster https://help.kusto.windows.net --database Samples --format markdown --chart
 
 # Save a column chart as a PNG (default 1200×675)
-kusto query "StormEvents | summarize Count=count() by State | top 5 by Count desc | render columnchart" --cluster help --database Samples --output-chart ./top-states.png
+kusto query "StormEvents | summarize Count=count() by State | top 5 by Count desc | render columnchart" --cluster https://help.kusto.windows.net --database Samples --output-chart ./top-states.png
 
 # Save a PNG and render in the terminal at the same time
-kusto query "StormEvents | summarize Count=count() by State | top 5 by Count desc | render columnchart" --cluster help --database Samples --chart --output-chart ./top-states.png
+kusto query "StormEvents | summarize Count=count() by State | top 5 by Count desc | render columnchart" --cluster https://help.kusto.windows.net --database Samples --chart --output-chart ./top-states.png
 
 # Save a PNG at a custom size
-kusto query "StormEvents | summarize Count=count() by State | top 5 by Count desc | render piechart" --cluster help --database Samples --output-chart ./pie.png --output-chart-width 1600 --output-chart-height 900
+kusto query "StormEvents | summarize Count=count() by State | top 5 by Count desc | render piechart" --cluster https://help.kusto.windows.net --database Samples --output-chart ./pie.png --output-chart-width 1600 --output-chart-height 900
 
 # Save a PNG while still streaming results as CSV
-kusto query "StormEvents | summarize Count=count() by State | top 5 by Count desc | render columnchart" --cluster help --database Samples --format csv --output-chart ./top-states.png > top-states.csv
+kusto query "StormEvents | summarize Count=count() by State | top 5 by Count desc | render columnchart" --cluster https://help.kusto.windows.net --database Samples --format csv --output-chart ./top-states.png > top-states.csv
 
 # Save a PNG while capturing results as JSON (chartOutputPath appears in the envelope)
-kusto query "StormEvents | summarize Count=count() by State | top 5 by Count desc | render columnchart" --cluster help --database Samples --format json --output-chart ./top-states.png
+kusto query "StormEvents | summarize Count=count() by State | top 5 by Count desc | render columnchart" --cluster https://help.kusto.windows.net --database Samples --format json --output-chart ./top-states.png
 ```
 
 ## Output formats
 
 ```powershell
 # Human-friendly terminal rendering
-kusto table list --cluster help --database Samples --format human
+kusto table list --cluster https://help.kusto.windows.net --database Samples --format human
 
 # JSON for scripts/tools
-kusto database list --cluster help --format json
+kusto database list --cluster https://help.kusto.windows.net --format json
 
 # Markdown for docs/issues
-kusto query "StormEvents | take 3" --cluster help --database Samples --format markdown
+kusto query "StormEvents | take 3" --cluster https://help.kusto.windows.net --database Samples --format markdown
 
 # CSV for redirecting query results
-kusto query "StormEvents | summarize EventCount = count() by State | top 10 by EventCount desc" --cluster help --database Samples --format csv > top-states.csv
+kusto query "StormEvents | summarize EventCount = count() by State | top 10 by EventCount desc" --cluster https://help.kusto.windows.net --database Samples --format csv > top-states.csv
 ```
 
 Human and markdown output show a short `Open in Web Explorer` link when available instead of printing the raw `webExplorerUrl`; JSON output still includes `webExplorerUrl`, and `--show-stats` adds `statistics`. CSV output is query-only and writes just the tabular result data to stdout, so `--chart` and `--show-stats` are rejected with `--format csv`.
@@ -467,7 +467,7 @@ Human and markdown output show a short `Open in Web Explorer` link when availabl
 - Use `--log-level` to emit console logs in addition to file logs.
 
 ```powershell
-kusto query "StormEvents | take 1" --cluster help --database Samples --log-level Information
+kusto query "StormEvents | take 1" --cluster https://help.kusto.windows.net --database Samples --log-level Information
 ```
 
 ## Installer script
@@ -629,7 +629,7 @@ The GitHub workflows install or configure the required toolchains for CI. When p
 ## Run from source
 
 ```powershell
-.\kusto --query "StormEvents | take 5" --cluster help --database Samples
+.\kusto query "StormEvents | take 5" --cluster https://help.kusto.windows.net --database Samples
 ```
 
 ## Publish the native executable locally

--- a/README.md
+++ b/README.md
@@ -629,7 +629,7 @@ The GitHub workflows install or configure the required toolchains for CI. When p
 ## Run from source
 
 ```powershell
-.\kusto query "StormEvents | take 5" --cluster https://help.kusto.windows.net --database Samples
+.\kusto.cmd query "StormEvents | take 5" --cluster https://help.kusto.windows.net --database Samples
 ```
 
 ## Publish the native executable locally

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -1,0 +1,68 @@
+# Third-party notices
+
+This product bundles software from the third-party packages listed below. Each
+package is the property of its respective copyright holders and is distributed
+under its own license. Licenses are reproduced under their canonical SPDX
+identifiers; full text is available at the package's listed source URL.
+
+This file is informational; the authoritative license text for each component
+is the LICENSE file shipped with that component's NuGet package or source
+distribution.
+
+## Direct dependency
+
+| Package | Version | License | Source |
+|---|---|---|---|
+| `ScottPlot` | 5.1.x | MIT | https://github.com/ScottPlot/ScottPlot |
+
+## Transitive native rendering stack
+
+`ScottPlot` pulls in the SkiaSharp/HarfBuzz native rendering stack and a few
+other utility packages. The relevant runtime dependencies that ship inside the
+released archives are:
+
+| Package | Version | License | Source |
+|---|---|---|---|
+| `SkiaSharp` | 3.x | MIT | https://github.com/mono/SkiaSharp |
+| `SkiaSharp.NativeAssets.Win32` | 3.x | MIT | https://github.com/mono/SkiaSharp |
+| `SkiaSharp.NativeAssets.Linux` | 3.x | MIT | https://github.com/mono/SkiaSharp |
+| `SkiaSharp.NativeAssets.macOS` | 3.x | MIT | https://github.com/mono/SkiaSharp |
+| `SkiaSharp.HarfBuzz` | 3.x | MIT | https://github.com/mono/SkiaSharp |
+| `HarfBuzzSharp` | 7.x | MIT | https://github.com/mono/SkiaSharp |
+| `HarfBuzzSharp.NativeAssets.*` | 7.x | MIT | https://github.com/mono/SkiaSharp |
+| `QRCoder` | 1.x | MIT | https://github.com/codebude/QRCoder |
+| `System.Drawing.Common` | 9.x | MIT | https://github.com/dotnet/runtime |
+
+The native sidecar libraries shipped next to `kusto`/`kusto.exe` in the release
+archives (e.g. `libSkiaSharp.dll`, `libHarfBuzzSharp.dll`, and their `.so` /
+`.dylib` equivalents) come from the corresponding `SkiaSharp.NativeAssets.*` /
+`HarfBuzzSharp.NativeAssets.*` packages and are covered by the MIT licenses
+above.
+
+## License summary
+
+All bundled third-party packages above are distributed under the MIT license.
+The MIT license is reproduced below for convenience and is the same canonical
+text used by every package above:
+
+```
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+```

--- a/scripts/Publish-NativeAsset.ps1
+++ b/scripts/Publish-NativeAsset.ps1
@@ -82,6 +82,69 @@ function Get-WindowsTargetArchitecture
     }
 }
 
+function Get-RequiredPayloadFileNames
+{
+    param(
+        [Parameter(Mandatory)][string]$RuntimeIdentifier,
+        [Parameter(Mandatory)][string]$BinaryName
+    )
+
+    $platform = $RuntimeIdentifier.Split('-', 2)[0]
+    switch ($platform)
+    {
+        'win'
+        {
+            return @(
+                $BinaryName,
+                'libSkiaSharp.dll',
+                'libHarfBuzzSharp.dll',
+                'LICENSE'
+            )
+        }
+        'linux'
+        {
+            return @(
+                $BinaryName,
+                'libSkiaSharp.so',
+                'libHarfBuzzSharp.so',
+                'LICENSE'
+            )
+        }
+        'osx'
+        {
+            return @(
+                $BinaryName,
+                'libSkiaSharp.dylib',
+                'libHarfBuzzSharp.dylib',
+                'LICENSE'
+            )
+        }
+        default
+        {
+            throw "Unsupported platform '$platform' in runtime identifier '$RuntimeIdentifier'."
+        }
+    }
+}
+
+function Assert-StagedPayloadComplete
+{
+    param(
+        [Parameter(Mandatory)][string]$StagingDirectory,
+        [Parameter(Mandatory)][string]$RuntimeIdentifier,
+        [Parameter(Mandatory)][string]$BinaryName
+    )
+
+    $required = Get-RequiredPayloadFileNames -RuntimeIdentifier $RuntimeIdentifier -BinaryName $BinaryName
+    $stagedFileNames = (Get-ChildItem -Path $StagingDirectory -File -Recurse | ForEach-Object { $_.Name }) | Sort-Object -Unique
+    $missing = @($required | Where-Object { $_ -notin $stagedFileNames })
+
+    if ($missing.Count -gt 0)
+    {
+        $stagedListing = (Get-ChildItem -Path $StagingDirectory -File -Recurse | ForEach-Object { $_.FullName.Substring($StagingDirectory.Length).TrimStart('\','/') }) -join "`n  "
+        throw "Staged payload for runtime '$RuntimeIdentifier' is missing required file(s): $($missing -join ', '). Staged contents:`n  $stagedListing"
+    }
+}
+
 function Invoke-DotNetPublish
 {
     param(
@@ -156,8 +219,49 @@ try
     }
 
     New-Item -ItemType Directory -Path $stagingDirectory -Force | Out-Null
-    Copy-Item $binaryPath (Join-Path $stagingDirectory $binaryName) -Force
+
+    # Copy the entire publish payload (not just the binary) so native sidecars
+    # required by SkiaSharp/HarfBuzz at runtime are included in the release
+    # archive. Skip debug symbols and IDE/build artifacts that aren't needed
+    # at runtime — these would only inflate the archive.
+    $excludePatterns = @('*.pdb', '*.xml', '*.deps.json.map', '*.dbg', '*.dwarf')
+    $payloadFiles = Get-ChildItem -Path $publishDirectory -File -Recurse |
+        Where-Object {
+            $relative = $_.FullName.Substring($publishDirectory.Length).TrimStart('\','/')
+            foreach ($pattern in $excludePatterns)
+            {
+                if ($_.Name -like $pattern) { return $false }
+            }
+            return $true
+        }
+
+    foreach ($file in $payloadFiles)
+    {
+        $relative = $file.FullName.Substring($publishDirectory.Length).TrimStart('\','/')
+        $destination = Join-Path $stagingDirectory $relative
+        $destinationDir = Split-Path -Parent $destination
+        if (-not [string]::IsNullOrEmpty($destinationDir) -and -not (Test-Path $destinationDir))
+        {
+            New-Item -ItemType Directory -Path $destinationDir -Force | Out-Null
+        }
+
+        Copy-Item $file.FullName $destination -Force
+    }
+
     Copy-Item (Join-Path $repoRoot 'LICENSE') (Join-Path $stagingDirectory 'LICENSE') -Force
+
+    $thirdPartyNoticesPath = Join-Path $repoRoot 'THIRD-PARTY-NOTICES.md'
+    if (Test-Path $thirdPartyNoticesPath)
+    {
+        Copy-Item $thirdPartyNoticesPath (Join-Path $stagingDirectory 'THIRD-PARTY-NOTICES.md') -Force
+    }
+
+    # Assert the staged payload contains every file users need at runtime. If
+    # ScottPlot/SkiaSharp ever drops a backend, restructures its native packaging,
+    # or stops publishing native assets for a RID, the missing-file failure here
+    # will fail the build instead of producing a broken archive that explodes
+    # with DllNotFoundException at first chart render.
+    Assert-StagedPayloadComplete -StagingDirectory $stagingDirectory -RuntimeIdentifier $RuntimeIdentifier -BinaryName $binaryName
 
     $assetPath =
         if ($platform -eq 'win')

--- a/scripts/Test-PackagedArchive.ps1
+++ b/scripts/Test-PackagedArchive.ps1
@@ -1,0 +1,149 @@
+# Hermetic packaged-artifact smoke test.
+#
+# Validates the release archive shape that users actually receive:
+#   1. Publish-NativeAsset.ps1 emits a self-contained archive.
+#   2. The archive expands to a directory containing kusto[.exe] plus all
+#      required native sidecars (libSkiaSharp.*, libHarfBuzzSharp.*).
+#   3. The extracted binary loads its native rendering stack and produces a
+#      valid PNG via the hidden `_diag chart-self-test` command. This catches
+#      DllNotFoundException-class failures that succeeded against the build
+#      output but explode when run from the archive payload.
+#
+# The test does not need network access, Kusto auth, or a live cluster — it
+# exercises the same SkiaSharp/HarfBuzz native loading path that real chart
+# rendering uses, against the actual archived binary.
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [string]$RuntimeIdentifier,
+
+    [string]$Version = '0.0.0-smoketest',
+
+    [string]$ArtifactsDirectory = (Join-Path $PSScriptRoot '..\artifacts\smoketest'),
+
+    [switch]$SkipPublish
+)
+
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..'))
+$artifactsDirectory = [System.IO.Path]::GetFullPath($ArtifactsDirectory)
+$publishScript = Join-Path $PSScriptRoot 'Publish-NativeAsset.ps1'
+
+if (-not (Test-Path $publishScript))
+{
+    throw "Publish script '$publishScript' not found."
+}
+
+$platform = $RuntimeIdentifier.Split('-', 2)[0]
+$binaryName = if ($platform -eq 'win') { 'kusto.exe' } else { 'kusto' }
+$archiveName = if ($platform -eq 'win') { "kusto-$RuntimeIdentifier.zip" } else { "kusto-$RuntimeIdentifier.tar.gz" }
+
+if (-not $SkipPublish)
+{
+    if (Test-Path $artifactsDirectory)
+    {
+        Remove-Item $artifactsDirectory -Recurse -Force
+    }
+    New-Item -ItemType Directory -Path $artifactsDirectory -Force | Out-Null
+
+    Write-Host "Publishing native asset for runtime '$RuntimeIdentifier'..." -ForegroundColor Cyan
+    & $publishScript -RuntimeIdentifier $RuntimeIdentifier -Version $Version -ArtifactsDirectory $artifactsDirectory
+}
+
+$archivePath = Join-Path $artifactsDirectory $archiveName
+if (-not (Test-Path $archivePath))
+{
+    throw "Expected archive '$archivePath' was not produced."
+}
+
+$expandRoot = Join-Path $artifactsDirectory ("expand-" + [System.Guid]::NewGuid().ToString('N'))
+New-Item -ItemType Directory -Path $expandRoot -Force | Out-Null
+
+try
+{
+    Write-Host "Expanding archive '$archivePath' to '$expandRoot'..." -ForegroundColor Cyan
+    if ($platform -eq 'win')
+    {
+        Expand-Archive -Path $archivePath -DestinationPath $expandRoot -Force
+    }
+    else
+    {
+        & tar -xzf $archivePath -C $expandRoot
+        if ($LASTEXITCODE -ne 0)
+        {
+            throw "Failed to extract archive '$archivePath'."
+        }
+    }
+
+    # Structural check: required files must be present in the expanded payload.
+    $requiredNames = switch ($platform)
+    {
+        'win'   { @('kusto.exe', 'libSkiaSharp.dll', 'libHarfBuzzSharp.dll', 'LICENSE') }
+        'linux' { @('kusto', 'libSkiaSharp.so', 'libHarfBuzzSharp.so', 'LICENSE') }
+        'osx'   { @('kusto', 'libSkiaSharp.dylib', 'libHarfBuzzSharp.dylib', 'LICENSE') }
+        default { throw "Unsupported platform '$platform'." }
+    }
+
+    $presentFiles = @(Get-ChildItem -Path $expandRoot -File -Recurse | ForEach-Object { $_.Name }) | Sort-Object -Unique
+    $missing = @($requiredNames | Where-Object { $_ -notin $presentFiles })
+    if ($missing.Count -gt 0)
+    {
+        $listing = ($presentFiles | Sort-Object) -join ', '
+        throw "Expanded archive is missing required file(s): $($missing -join ', '). Found: $listing"
+    }
+
+    Write-Host "Required payload files present: $($requiredNames -join ', ')" -ForegroundColor Green
+
+    # Runtime check: invoke the binary from the expanded archive, not from the
+    # build output. This proves SkiaSharp/HarfBuzz native libraries actually
+    # load via the host's normal probing rules from a fresh install layout.
+    $binaryPath = Join-Path $expandRoot $binaryName
+    if (-not (Test-Path $binaryPath))
+    {
+        throw "Extracted binary '$binaryPath' was not found."
+    }
+
+    if ($platform -ne 'win')
+    {
+        & chmod +x $binaryPath
+    }
+
+    $smokePngPath = Join-Path $expandRoot 'self-test.png'
+    Write-Host "Running '$binaryPath _diag chart-self-test --output $smokePngPath'..." -ForegroundColor Cyan
+    & $binaryPath '_diag' 'chart-self-test' '--output' $smokePngPath
+    if ($LASTEXITCODE -ne 0)
+    {
+        throw "Chart self-test command exited with code $LASTEXITCODE. Native chart-rendering dependencies likely failed to load from the archived payload."
+    }
+
+    if (-not (Test-Path $smokePngPath))
+    {
+        throw "Chart self-test reported success but '$smokePngPath' was not written."
+    }
+
+    $bytes = [System.IO.File]::ReadAllBytes($smokePngPath)
+    if ($bytes.Length -lt 100)
+    {
+        throw "Self-test PNG '$smokePngPath' is suspiciously small ($($bytes.Length) bytes)."
+    }
+
+    $pngSignature = @(0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A)
+    for ($i = 0; $i -lt $pngSignature.Length; $i++)
+    {
+        if ($bytes[$i] -ne $pngSignature[$i])
+        {
+            throw "Self-test PNG '$smokePngPath' does not start with the PNG signature at byte $i (got 0x$($bytes[$i].ToString('X2')))."
+        }
+    }
+
+    Write-Host "Smoke test passed for runtime '$RuntimeIdentifier'. PNG: $smokePngPath ($($bytes.Length) bytes)." -ForegroundColor Green
+}
+finally
+{
+    if (Test-Path $expandRoot)
+    {
+        Remove-Item $expandRoot -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}

--- a/scripts/Verify-WindowsBinaryIssuer.ps1
+++ b/scripts/Verify-WindowsBinaryIssuer.ps1
@@ -1,20 +1,17 @@
 [CmdletBinding()]
 param(
-    [Parameter(Mandatory)]
+    [Parameter(Mandatory, ParameterSetName = 'SingleBinary')]
     [string]$BinaryPath,
+
+    [Parameter(Mandatory, ParameterSetName = 'PayloadDirectory')]
+    [string]$PayloadDirectory,
 
     [string]$InstallerScriptPath = (Join-Path $PSScriptRoot 'install\install-kusto-cli.ps1')
 )
 
 $ErrorActionPreference = 'Stop'
 
-$binaryPath = [System.IO.Path]::GetFullPath($BinaryPath)
 $installerScriptPath = [System.IO.Path]::GetFullPath($InstallerScriptPath)
-
-if (-not (Test-Path $binaryPath))
-{
-    throw "Signed binary '$binaryPath' was not found."
-}
 
 if (-not (Test-Path $installerScriptPath))
 {
@@ -27,22 +24,70 @@ Write-Verbose "Loading installer trust helpers from '$installerScriptPath'."
 $config = Get-KustoInstallerTrustConfiguration
 $expectedThumbprints = @($config.ExpectedSignerIssuerSha512Thumbprints)
 $expectedParentThumbprints = @($config.ExpectedSignerParentIssuerSha512Thumbprints)
-$evidence = Get-WindowsBinaryTrustEvidence -BinaryPath $binaryPath
 
-$issuerTrustMatch = Assert-SignerIssuerTrust `
-    -Evidence $evidence `
-    -ExpectedIssuerThumbprints $expectedThumbprints `
-    -ExpectedParentIssuerThumbprints $expectedParentThumbprints
-
-$formattedExpectedThumbprints = ($expectedThumbprints | ForEach-Object { "'$_'" }) -join ', '
-$formattedExpectedParentThumbprints = ($expectedParentThumbprints | ForEach-Object { "'$_'" }) -join ', '
-$matchDescription = if ($issuerTrustMatch.UsedFallback)
+$binariesToVerify = @()
+if ($PSCmdlet.ParameterSetName -eq 'SingleBinary')
 {
-    "using parent issuer fallback '$($issuerTrustMatch.Certificate.Subject)' ($($issuerTrustMatch.Sha512Thumbprint))"
+    $resolvedBinaryPath = [System.IO.Path]::GetFullPath($BinaryPath)
+    if (-not (Test-Path $resolvedBinaryPath))
+    {
+        throw "Signed binary '$resolvedBinaryPath' was not found."
+    }
+    $binariesToVerify = @($resolvedBinaryPath)
 }
 else
 {
-    "using immediate issuer '$($issuerTrustMatch.Certificate.Subject)' ($($issuerTrustMatch.Sha512Thumbprint))"
+    $resolvedPayloadDirectory = [System.IO.Path]::GetFullPath($PayloadDirectory)
+    if (-not (Test-Path $resolvedPayloadDirectory))
+    {
+        throw "Payload directory '$resolvedPayloadDirectory' was not found."
+    }
+
+    $expectedExecutableFiles = @($config.ExpectedExecutablePayloadFiles)
+    if ($expectedExecutableFiles.Count -eq 0)
+    {
+        throw "Installer trust configuration does not list any expected executable payload files."
+    }
+
+    $missing = @()
+    foreach ($name in $expectedExecutableFiles)
+    {
+        $candidate = Join-Path $resolvedPayloadDirectory $name
+        if (-not (Test-Path $candidate))
+        {
+            $missing += $name
+        }
+        else
+        {
+            $binariesToVerify += $candidate
+        }
+    }
+
+    if ($missing.Count -gt 0)
+    {
+        throw "Payload directory '$resolvedPayloadDirectory' is missing required executable file(s): $($missing -join ', ')."
+    }
 }
 
-Write-Host "Verified signer issuer chain for '$binaryPath' $matchDescription. Allowed immediate SHA512 thumbprints: $formattedExpectedThumbprints. Allowed parent SHA512 thumbprints: $formattedExpectedParentThumbprints."
+$formattedExpectedThumbprints = ($expectedThumbprints | ForEach-Object { "'$_'" }) -join ', '
+$formattedExpectedParentThumbprints = ($expectedParentThumbprints | ForEach-Object { "'$_'" }) -join ', '
+
+foreach ($binary in $binariesToVerify)
+{
+    $evidence = Get-WindowsBinaryTrustEvidence -BinaryPath $binary
+    $issuerTrustMatch = Assert-SignerIssuerTrust `
+        -Evidence $evidence `
+        -ExpectedIssuerThumbprints $expectedThumbprints `
+        -ExpectedParentIssuerThumbprints $expectedParentThumbprints
+
+    $matchDescription = if ($issuerTrustMatch.UsedFallback)
+    {
+        "using parent issuer fallback '$($issuerTrustMatch.Certificate.Subject)' ($($issuerTrustMatch.Sha512Thumbprint))"
+    }
+    else
+    {
+        "using immediate issuer '$($issuerTrustMatch.Certificate.Subject)' ($($issuerTrustMatch.Sha512Thumbprint))"
+    }
+
+    Write-Host "Verified signer issuer chain for '$binary' $matchDescription. Allowed immediate SHA512 thumbprints: $formattedExpectedThumbprints. Allowed parent SHA512 thumbprints: $formattedExpectedParentThumbprints."
+}

--- a/scripts/install/install-kusto-cli.ps1
+++ b/scripts/install/install-kusto-cli.ps1
@@ -298,6 +298,23 @@ function Get-KustoInstallerTrustConfiguration
         ExpectedSignerSubject = $ExpectedSignerSubject
         ExpectedSignerIssuerSha512Thumbprints = @($ExpectedSignerIssuerSha512Thumbprints)
         ExpectedSignerParentIssuerSha512Thumbprints = @($ExpectedSignerParentIssuerSha512Thumbprints)
+        # Expected executable payload files inside a Windows release archive. Every
+        # file listed here must be present after extraction, must be Authenticode-signed
+        # by the configured signer, and is also tracked by the installer so that
+        # upgrades can clean up sidecars that future versions remove. Update this list
+        # alongside any change to the publish/signing pipeline (see
+        # scripts/Publish-NativeAsset.ps1).
+        ExpectedExecutablePayloadFiles = @(
+            'kusto.exe',
+            'libSkiaSharp.dll',
+            'libHarfBuzzSharp.dll'
+        )
+        # Non-executable payload files that should be carried alongside the binaries.
+        # These don't need signing but the installer should still keep them in sync.
+        ExpectedAuxiliaryPayloadFiles = @(
+            'LICENSE',
+            'THIRD-PARTY-NOTICES.md'
+        )
     }
 }
 
@@ -444,7 +461,146 @@ function Expand-WindowsReleaseArchive
     }
 
     Write-Verbose "Found extracted Windows binary '$binaryPath'."
-    return $binaryPath
+    return [pscustomobject]@{
+        BinaryPath = $binaryPath
+        ExtractDirectory = $DestinationPath
+    }
+}
+
+function Assert-ExtractedPayloadComplete
+{
+    param(
+        [Parameter(Mandatory)][string]$ExtractDirectory,
+        [Parameter(Mandatory)][string[]]$RequiredFileNames
+    )
+
+    $present = @(Get-ChildItem -Path $ExtractDirectory -File | ForEach-Object { $_.Name })
+    $missing = @($RequiredFileNames | Where-Object { $_ -notin $present })
+    if ($missing.Count -gt 0)
+    {
+        $listing = ($present | Sort-Object) -join ', '
+        throw "Extracted archive at '$ExtractDirectory' is missing required file(s): $($missing -join ', '). Found: $listing."
+    }
+}
+
+function Install-KustoPayload
+{
+    param(
+        [Parameter(Mandatory)][string]$SourceDirectory,
+        [Parameter(Mandatory)][string]$InstallDirectory,
+        [string[]]$KnownPayloadFileNames = @()
+    )
+
+    # Strategy: stage the new payload to a sibling ".new" directory, then atomically
+    # replace the install dir by renaming the existing dir aside, renaming the new
+    # one in, and deleting the side-aside dir. If anything in the rename dance fails
+    # (e.g. another process holds a file open), fall back to overlay-copy + cleanup
+    # of stale managed files so the upgrade still completes.
+
+    $installRoot = [System.IO.Path]::GetFullPath($InstallDirectory)
+    $stagingDir = $installRoot + '.new'
+    $previousDir = $installRoot + '.old'
+
+    if (Test-Path $stagingDir)
+    {
+        Remove-Item $stagingDir -Recurse -Force
+    }
+    if (Test-Path $previousDir)
+    {
+        Remove-Item $previousDir -Recurse -Force
+    }
+
+    # Stage: copy the entire extracted payload into installRoot.new
+    New-Item -ItemType Directory -Path $stagingDir -Force | Out-Null
+    Copy-Item -Path (Join-Path $SourceDirectory '*') -Destination $stagingDir -Recurse -Force
+
+    $atomicSwapCompleted = $false
+    if (Test-Path $installRoot)
+    {
+        try
+        {
+            Rename-Item -Path $installRoot -NewName ([System.IO.Path]::GetFileName($previousDir)) -ErrorAction Stop
+            try
+            {
+                Rename-Item -Path $stagingDir -NewName ([System.IO.Path]::GetFileName($installRoot)) -ErrorAction Stop
+                $atomicSwapCompleted = $true
+            }
+            catch
+            {
+                # Couldn't rename staging in. Restore the previous dir.
+                Write-Verbose "Atomic install swap failed renaming staging into place; restoring previous install. $($_.Exception.Message)"
+                if (-not (Test-Path $installRoot))
+                {
+                    Rename-Item -Path $previousDir -NewName ([System.IO.Path]::GetFileName($installRoot)) -ErrorAction SilentlyContinue
+                }
+                throw
+            }
+        }
+        catch [System.IO.IOException]
+        {
+            Write-Verbose "Atomic install swap unavailable (likely a file is in use). Falling back to overlay copy. $($_.Exception.Message)"
+        }
+    }
+    else
+    {
+        Rename-Item -Path $stagingDir -NewName ([System.IO.Path]::GetFileName($installRoot)) -ErrorAction Stop
+        $atomicSwapCompleted = $true
+    }
+
+    if ($atomicSwapCompleted)
+    {
+        if (Test-Path $previousDir)
+        {
+            try
+            {
+                Remove-Item $previousDir -Recurse -Force
+            }
+            catch
+            {
+                Write-Verbose "Could not delete previous install at '$previousDir' after swap. $($_.Exception.Message)"
+            }
+        }
+
+        if (Test-Path $stagingDir)
+        {
+            Remove-Item $stagingDir -Recurse -Force -ErrorAction SilentlyContinue
+        }
+
+        return
+    }
+
+    # Fallback overlay path. First, remove stale known-managed files so previously
+    # installed sidecars that the new release dropped don't linger and shadow the
+    # ones bundled with .NET host probing.
+    if (Test-Path $installRoot)
+    {
+        foreach ($knownName in $KnownPayloadFileNames)
+        {
+            $stalePath = Join-Path $installRoot $knownName
+            if (Test-Path $stalePath)
+            {
+                try
+                {
+                    Remove-Item $stalePath -Force
+                }
+                catch
+                {
+                    Write-Verbose "Could not delete stale managed file '$stalePath' before overlay copy. $($_.Exception.Message)"
+                }
+            }
+        }
+    }
+    else
+    {
+        New-Item -ItemType Directory -Path $installRoot -Force | Out-Null
+    }
+
+    Copy-Item -Path (Join-Path $stagingDir '*') -Destination $installRoot -Recurse -Force
+
+    if (Test-Path $stagingDir)
+    {
+        Remove-Item $stagingDir -Recurse -Force -ErrorAction SilentlyContinue
+    }
 }
 
 function Invoke-StatusStep
@@ -1056,12 +1212,28 @@ function Invoke-KustoCliInstall
             }
         }
 
-        $downloadedBinaryPath = Expand-WindowsReleaseArchive -ArchivePath $downloadPath -DestinationPath $extractPath
+        $extractedPayload = Expand-WindowsReleaseArchive -ArchivePath $downloadPath -DestinationPath $extractPath
+        $downloadedBinaryPath = $extractedPayload.BinaryPath
+        $extractDirectory = $extractedPayload.ExtractDirectory
+
+        $trustConfig = Get-KustoInstallerTrustConfiguration
+        $expectedExecutablePayload = @($trustConfig.ExpectedExecutablePayloadFiles)
+        $expectedAuxiliaryPayload = @($trustConfig.ExpectedAuxiliaryPayloadFiles)
+        $allExpectedPayload = @($expectedExecutablePayload + $expectedAuxiliaryPayload)
+
+        Assert-ExtractedPayloadComplete -ExtractDirectory $extractDirectory -RequiredFileNames $expectedExecutablePayload
 
         if ($Quality -ne 'Dev')
         {
             Invoke-StatusStep -Message 'Verifying asset provenance' -Action {
-                $null = Assert-WindowsBinaryTrust -BinaryPath $downloadedBinaryPath -ExpectedSubject $ExpectedSignerSubject -ExpectedIssuerSha512Thumbprints $ExpectedSignerIssuerSha512Thumbprints -ExpectedParentIssuerSha512Thumbprints $ExpectedSignerParentIssuerSha512Thumbprints
+                # Verify Authenticode trust on every executable payload file (kusto.exe + native sidecars).
+                # Treating the .exe alone as the trust signal would let an unsigned/swapped libSkiaSharp.dll
+                # be loaded by a signed kusto.exe at first chart render.
+                foreach ($payloadName in $expectedExecutablePayload)
+                {
+                    $payloadPath = Join-Path $extractDirectory $payloadName
+                    $null = Assert-WindowsBinaryTrust -BinaryPath $payloadPath -ExpectedSubject $ExpectedSignerSubject -ExpectedIssuerSha512Thumbprints $ExpectedSignerIssuerSha512Thumbprints -ExpectedParentIssuerSha512Thumbprints $ExpectedSignerParentIssuerSha512Thumbprints
+                }
             }
         }
         else
@@ -1095,7 +1267,10 @@ function Invoke-KustoCliInstall
         if ($shouldInstall)
         {
             Invoke-StatusStep -Message "Installing $downloadedVersion to '$installDirectory'" -Action {
-                Copy-Item -Path $downloadedBinaryPath -Destination $destinationPath -Force
+                Install-KustoPayload `
+                    -SourceDirectory $extractDirectory `
+                    -InstallDirectory $installDirectory `
+                    -KnownPayloadFileNames $allExpectedPayload
             }
         }
 

--- a/src/Kusto.Cli/ChartImageWriter.cs
+++ b/src/Kusto.Cli/ChartImageWriter.cs
@@ -1,0 +1,93 @@
+using System.Globalization;
+
+namespace Kusto.Cli;
+
+internal static class ChartImageWriter
+{
+    public static async Task<string> WritePngAsync(
+        QueryChartDefinition chart,
+        string path,
+        int width,
+        int height,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(chart);
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            throw new UserFacingException("--output-chart requires a non-empty file path.");
+        }
+
+        var extension = Path.GetExtension(path);
+        if (!string.Equals(extension, ".png", StringComparison.OrdinalIgnoreCase))
+        {
+            throw new UserFacingException($"--output-chart requires a path ending in .png; got '{(string.IsNullOrEmpty(extension) ? "(no extension)" : extension)}'.");
+        }
+
+        if (width < ChartStyle.MinDimension || width > ChartStyle.MaxDimension)
+        {
+            throw new UserFacingException(string.Format(
+                CultureInfo.InvariantCulture,
+                "--output-chart-width must be between {0} and {1} pixels.",
+                ChartStyle.MinDimension,
+                ChartStyle.MaxDimension));
+        }
+
+        if (height < ChartStyle.MinDimension || height > ChartStyle.MaxDimension)
+        {
+            throw new UserFacingException(string.Format(
+                CultureInfo.InvariantCulture,
+                "--output-chart-height must be between {0} and {1} pixels.",
+                ChartStyle.MinDimension,
+                ChartStyle.MaxDimension));
+        }
+
+        var fullPath = Path.GetFullPath(path);
+
+        if (Directory.Exists(fullPath))
+        {
+            throw new UserFacingException($"--output-chart target '{fullPath}' is an existing directory.");
+        }
+
+        var directory = Path.GetDirectoryName(fullPath);
+        if (!string.IsNullOrEmpty(directory) && !Directory.Exists(directory))
+        {
+            try
+            {
+                Directory.CreateDirectory(directory);
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+            {
+                throw new UserFacingException($"Couldn't create directory '{directory}' for chart output: {ex.Message}");
+            }
+        }
+
+        var tempPath = fullPath + ".tmp";
+        try
+        {
+            await using (var stream = new FileStream(tempPath, FileMode.Create, FileAccess.Write, FileShare.None))
+            {
+                ImageChartRenderer.RenderPng(chart, width, height, stream);
+                await stream.FlushAsync(cancellationToken);
+            }
+
+            File.Move(tempPath, fullPath, overwrite: true);
+        }
+        catch
+        {
+            try
+            {
+                if (File.Exists(tempPath))
+                {
+                    File.Delete(tempPath);
+                }
+            }
+            catch
+            {
+            }
+            throw;
+        }
+
+        return fullPath;
+    }
+}
+

--- a/src/Kusto.Cli/ChartStyle.cs
+++ b/src/Kusto.Cli/ChartStyle.cs
@@ -1,0 +1,29 @@
+namespace Kusto.Cli;
+
+internal static class ChartStyle
+{
+    public const int MinDimension = 200;
+    public const int MaxDimension = 8192;
+    public const int DefaultWidth = 1200;
+    public const int DefaultHeight = 675;
+
+    // Tableau-inspired categorical palette (R, G, B)
+    private static readonly (byte R, byte G, byte B)[] Palette =
+    [
+        (0x1F, 0x77, 0xB4),
+        (0xD6, 0x27, 0x28),
+        (0x2C, 0xA0, 0x2C),
+        (0x94, 0x67, 0xBD),
+        (0xFF, 0x7F, 0x0E),
+        (0x17, 0xBE, 0xCF),
+        (0x8C, 0x56, 0x4B),
+        (0x7F, 0x7F, 0x7F),
+        (0xBC, 0xBD, 0x22),
+        (0xE3, 0x77, 0xC2)
+    ];
+
+    public static (byte R, byte G, byte B) SeriesColorRgb(int index)
+    {
+        return Palette[((index % Palette.Length) + Palette.Length) % Palette.Length];
+    }
+}

--- a/src/Kusto.Cli/CommandFactory.cs
+++ b/src/Kusto.Cli/CommandFactory.cs
@@ -812,6 +812,20 @@ public static class CommandFactory
         {
             Description = "Render compatible query charts in the terminal for human output or as Mermaid for markdown output."
         };
+        var outputChartOption = new Option<string?>("--output-chart")
+        {
+            Description = "Write the rendered chart to a PNG file at the given path. Works with any --format. Suppresses raw data output."
+        };
+        var outputChartWidthOption = new Option<int>("--output-chart-width")
+        {
+            Description = $"PNG width in pixels for --output-chart (default {ChartStyle.DefaultWidth}, range {ChartStyle.MinDimension}..{ChartStyle.MaxDimension}).",
+            DefaultValueFactory = _ => ChartStyle.DefaultWidth
+        };
+        var outputChartHeightOption = new Option<int>("--output-chart-height")
+        {
+            Description = $"PNG height in pixels for --output-chart (default {ChartStyle.DefaultHeight}, range {ChartStyle.MinDimension}..{ChartStyle.MaxDimension}).",
+            DefaultValueFactory = _ => ChartStyle.DefaultHeight
+        };
 
         queryCommand.Add(queryArgument);
         queryCommand.Add(queryFileOption);
@@ -819,6 +833,9 @@ public static class CommandFactory
         queryCommand.Add(databaseOption);
         queryCommand.Add(showStatsOption);
         queryCommand.Add(chartOption);
+        queryCommand.Add(outputChartOption);
+        queryCommand.Add(outputChartWidthOption);
+        queryCommand.Add(outputChartHeightOption);
         queryCommand.SetAction((parseResult, cancellationToken) =>
         {
             var queryText = parseResult.GetValue(queryArgument);
@@ -827,6 +844,11 @@ public static class CommandFactory
             var databaseName = parseResult.GetValue(databaseOption);
             var showStats = parseResult.GetValue(showStatsOption);
             var showChart = parseResult.GetValue(chartOption);
+            var chartOutputPath = parseResult.GetValue(outputChartOption);
+            var chartWidth = parseResult.GetValue(outputChartWidthOption);
+            var chartHeight = parseResult.GetValue(outputChartHeightOption);
+            var chartWidthSpecified = parseResult.GetResult(outputChartWidthOption) is { Implicit: false };
+            var chartHeightSpecified = parseResult.GetResult(outputChartHeightOption) is { Implicit: false };
             var format = parseResult.GetRequiredValue(formatOption);
             var logLevel = parseResult.GetValue(logLevelOption);
 
@@ -844,6 +866,11 @@ public static class CommandFactory
                 if (showStats && isCsvOutput)
                 {
                     throw new UserFacingException("--show-stats can't be used with --format csv.");
+                }
+
+                if (string.IsNullOrEmpty(chartOutputPath) && (chartWidthSpecified || chartHeightSpecified))
+                {
+                    throw new UserFacingException("--output-chart-width and --output-chart-height require --output-chart.");
                 }
 
                 var config = await runtime.ConfigStore.LoadAsync(ct);
@@ -869,6 +896,7 @@ public static class CommandFactory
                 string? humanChart = null;
                 string? humanChartAnsi = null;
                 string? markdownChart = null;
+                string? chartOutputWritten = null;
                 if (result.Visualization is not null)
                 {
                     var compatibility = KustoChartCompatibilityAnalyzer.Analyze(result.Table, result.Visualization);
@@ -899,15 +927,39 @@ public static class CommandFactory
                             }
                         }
                     }
-                    else if (!isMarkdownOutput && !isCsvOutput && compatibility.HumanChart is not null)
+                    else if (!isMarkdownOutput && !isCsvOutput && compatibility.HumanChart is not null && string.IsNullOrEmpty(chartOutputPath))
                     {
                         chartHint = "This query can be rendered as a terminal chart. Re-run with --chart to see it.";
                     }
+
+                    if (!string.IsNullOrEmpty(chartOutputPath))
+                    {
+                        if (compatibility.HumanChart is null)
+                        {
+                            throw new UserFacingException(compatibility.HumanReason ?? "This query's render kind isn't supported for image output.");
+                        }
+
+                        chartOutputWritten = await ChartImageWriter.WritePngAsync(
+                            compatibility.HumanChart,
+                            chartOutputPath!,
+                            chartWidth,
+                            chartHeight,
+                            ct);
+
+                        if (isCsvOutput)
+                        {
+                            Console.Error.WriteLine($"Chart written to {chartOutputWritten}");
+                        }
+                    }
+                }
+                else if (!string.IsNullOrEmpty(chartOutputPath))
+                {
+                    throw new UserFacingException("--output-chart requires the query to include a 'render' annotation.");
                 }
 
                 return new CliOutput
                 {
-                    Table = result.Table,
+                    Table = string.IsNullOrEmpty(chartOutputPath) ? result.Table : null,
                     WebExplorerUrl = result.WebExplorerUrl,
                     Statistics = result.Statistics,
                     Visualization = result.Visualization,
@@ -916,6 +968,7 @@ public static class CommandFactory
                     HumanChart = humanChart,
                     HumanChartAnsi = humanChartAnsi,
                     MarkdownChart = markdownChart,
+                    ChartOutputPath = chartOutputWritten,
                     IsQueryResultTable = true
                 };
             }, cancellationToken, OutputFormat.Human, OutputFormat.Json, OutputFormat.Markdown, OutputFormat.Csv);
@@ -1036,3 +1089,5 @@ public static class CommandFactory
         }
     }
 }
+
+

--- a/src/Kusto.Cli/CommandFactory.cs
+++ b/src/Kusto.Cli/CommandFactory.cs
@@ -28,9 +28,70 @@ public static class CommandFactory
             BuildClusterCommand(formatOption, logLevelOption),
             BuildDatabaseCommand(formatOption, logLevelOption),
             BuildTableCommand(formatOption, logLevelOption),
-            BuildQueryCommand(formatOption, logLevelOption)
+            BuildQueryCommand(formatOption, logLevelOption),
+            BuildDiagnosticsCommand()
         };
         return root;
+    }
+
+    private static Command BuildDiagnosticsCommand()
+    {
+        // Hidden top-level command for packaging/runtime smoke tests. The first
+        // subcommand exists so CI can verify that the released archive can load
+        // SkiaSharp/HarfBuzz native sidecars and produce a real PNG without
+        // requiring authenticated access to a Kusto cluster.
+        var diagCommand = new Command("_diag", "Diagnostic commands for packaging/runtime smoke tests.")
+        {
+            Hidden = true
+        };
+
+        var chartSelfTest = new Command("chart-self-test", "Render a fixed sample chart to a PNG path. Used to verify native chart-rendering dependencies on a fresh install.")
+        {
+            Hidden = true
+        };
+
+        var outputOption = new Option<string>("--output")
+        {
+            Description = "Path to the PNG file to write.",
+            Required = true
+        };
+
+        chartSelfTest.Add(outputOption);
+        chartSelfTest.SetAction(async (parseResult, cancellationToken) =>
+        {
+            var output = parseResult.GetRequiredValue(outputOption);
+
+            var chart = new QueryChartDefinition
+            {
+                Kind = QueryChartKind.Column,
+                Title = "kusto chart self-test",
+                XTitle = "category",
+                YTitle = "value",
+                Categories = ["alpha", "beta", "gamma", "delta"],
+                Series = [new QueryChartSeries("sample", [10, 25, 15, 40])]
+            };
+
+            try
+            {
+                var written = await ChartImageWriter.WritePngAsync(
+                    chart,
+                    output,
+                    ChartStyle.DefaultWidth,
+                    ChartStyle.DefaultHeight,
+                    cancellationToken);
+
+                Console.Out.WriteLine($"Chart self-test written to {written}");
+                return 0;
+            }
+            catch (UserFacingException ex)
+            {
+                Console.Error.WriteLine($"kusto: {ex.Message}");
+                return 1;
+            }
+        });
+
+        diagCommand.Add(chartSelfTest);
+        return diagCommand;
     }
 
     private static Command BuildExamplesCommand(Option<string> formatOption, Option<string?> logLevelOption)
@@ -814,7 +875,7 @@ public static class CommandFactory
         };
         var outputChartOption = new Option<string?>("--output-chart")
         {
-            Description = "Write the rendered chart to a PNG file at the given path. Works with any --format. Suppresses raw data output."
+            Description = "Write the rendered chart to a PNG file at the given path. Works with any --format. For human/markdown/json suppresses raw data on stdout and emits a chart-written confirmation. For csv keeps the CSV on stdout and writes the confirmation to stderr."
         };
         var outputChartWidthOption = new Option<int>("--output-chart-width")
         {
@@ -946,6 +1007,10 @@ public static class CommandFactory
                             chartHeight,
                             ct);
 
+                        // CSV output is a pure data stream meant for redirection (e.g. `> data.csv`).
+                        // Surface the chart confirmation on stderr only so it doesn't pollute the
+                        // CSV stream. For human/markdown/json the confirmation flows through
+                        // CliOutput.ChartOutputPath via the formatter.
                         if (isCsvOutput)
                         {
                             Console.Error.WriteLine($"Chart written to {chartOutputWritten}");
@@ -957,9 +1022,15 @@ public static class CommandFactory
                     throw new UserFacingException("--output-chart requires the query to include a 'render' annotation.");
                 }
 
+                // When --output-chart writes a PNG, suppress the tabular data from stdout for
+                // display formats (human/markdown/json) — the chart already conveys it. Keep
+                // the table for CSV so `--format csv --output-chart x.png > data.csv` produces
+                // both the PNG (side effect) and the CSV stream (stdout). The chart-written
+                // confirmation goes to stderr in that case (see above).
+                var suppressTable = !string.IsNullOrEmpty(chartOutputPath) && !isCsvOutput;
                 return new CliOutput
                 {
-                    Table = string.IsNullOrEmpty(chartOutputPath) ? result.Table : null,
+                    Table = suppressTable ? null : result.Table,
                     WebExplorerUrl = result.WebExplorerUrl,
                     Statistics = result.Statistics,
                     Visualization = result.Visualization,

--- a/src/Kusto.Cli/ImageChartRenderer.cs
+++ b/src/Kusto.Cli/ImageChartRenderer.cs
@@ -1,0 +1,377 @@
+using SP = ScottPlot;
+
+namespace Kusto.Cli;
+
+internal static class ImageChartRenderer
+{
+    public static void RenderPng(QueryChartDefinition chart, int width, int height, Stream output)
+    {
+        ArgumentNullException.ThrowIfNull(chart);
+        ArgumentNullException.ThrowIfNull(output);
+
+        if (width < ChartStyle.MinDimension || width > ChartStyle.MaxDimension)
+        {
+            throw new ArgumentOutOfRangeException(nameof(width));
+        }
+
+        if (height < ChartStyle.MinDimension || height > ChartStyle.MaxDimension)
+        {
+            throw new ArgumentOutOfRangeException(nameof(height));
+        }
+
+        ValidateChart(chart);
+
+        var plt = new SP.Plot();
+        plt.FigureBackground.Color = SP.Colors.White;
+
+        switch (chart.Kind)
+        {
+            case QueryChartKind.Pie:
+                AddPie(plt, chart);
+                break;
+            case QueryChartKind.Line:
+                AddLine(plt, chart);
+                break;
+            case QueryChartKind.Column:
+                AddBars(plt, chart, horizontal: false);
+                break;
+            case QueryChartKind.Bar:
+                AddBars(plt, chart, horizontal: true);
+                break;
+        }
+
+        if (!string.IsNullOrWhiteSpace(chart.Title))
+        {
+            plt.Title(chart.Title);
+        }
+
+        if (!string.IsNullOrWhiteSpace(chart.XTitle))
+        {
+            plt.XLabel(chart.XTitle);
+        }
+
+        if (!string.IsNullOrWhiteSpace(chart.YTitle))
+        {
+            plt.YLabel(chart.YTitle);
+        }
+
+        output.Write(plt.GetImage(width, height).GetImageBytes());
+    }
+
+    private static void ValidateChart(QueryChartDefinition chart)
+    {
+        var expected = chart.Categories.Count;
+        for (var i = 0; i < chart.Series.Count; i++)
+        {
+            var s = chart.Series[i];
+            if (s.Values.Count != expected)
+            {
+                throw new InvalidOperationException(
+                    $"Chart series '{s.Name}' has {s.Values.Count} values but {expected} categories. " +
+                    "All series must align with categories.");
+            }
+        }
+
+        if (chart.DateTimeCategories is not null && chart.DateTimeCategories.Length != expected)
+        {
+            throw new InvalidOperationException(
+                $"Chart has {chart.DateTimeCategories.Length} datetime categories but {expected} string categories.");
+        }
+    }
+
+    private static SP.Color SeriesColor(int index)
+    {
+        var (r, g, b) = ChartStyle.SeriesColorRgb(index);
+        return new SP.Color(r, g, b);
+    }
+
+    private static void AddPie(SP.Plot plt, QueryChartDefinition chart)
+    {
+        if (chart.Series.Count == 0 || chart.Categories.Count == 0)
+        {
+            return;
+        }
+
+        var slices = new List<SP.PieSlice>(chart.Categories.Count);
+        for (var i = 0; i < chart.Categories.Count; i++)
+        {
+            var v = chart.Series[0].Values[i];
+            // Skip NaN/non-positive slices rather than aborting the whole render.
+            if (double.IsNaN(v) || v <= 0)
+            {
+                continue;
+            }
+
+            slices.Add(new SP.PieSlice
+            {
+                Value = v,
+                FillColor = SeriesColor(i),
+                LegendText = chart.Categories[i],
+                Label = chart.Categories[i],
+            });
+        }
+
+        if (slices.Count == 0)
+        {
+            return;
+        }
+
+        plt.Add.Pie(slices);
+        plt.HideAxesAndGrid();
+        plt.Legend.IsVisible = true;
+    }
+
+    private static void AddLine(SP.Plot plt, QueryChartDefinition chart)
+    {
+        if (chart.Series.Count == 0 || chart.Categories.Count == 0)
+        {
+            return;
+        }
+
+        var isDatetime = chart.DateTimeCategories is not null;
+        var catCount = chart.Categories.Count;
+
+        var xValues = isDatetime
+            ? chart.DateTimeCategories!.Select(d => d.ToOADate()).ToArray()
+            : Enumerable.Range(0, catCount).Select(i => (double)i).ToArray();
+
+        // For stacked layouts, accumulate y values across series.
+        // NaN values are treated as 0 for the stack accumulator (the "missing"
+        // contribution is zero) but the original NaN is preserved in the Y array
+        // so ScottPlot creates a gap at that point.
+        var cumulative = chart.Layout is QueryChartLayout.Stacked or QueryChartLayout.Stacked100
+            ? new double[catCount]
+            : null;
+
+        double[]? totals = null;
+        if (chart.Layout == QueryChartLayout.Stacked100)
+        {
+            totals = new double[catCount];
+            foreach (var s in chart.Series)
+            {
+                for (var i = 0; i < s.Values.Count; i++)
+                {
+                    if (!double.IsNaN(s.Values[i]))
+                    {
+                        totals[i] += s.Values[i];
+                    }
+                }
+            }
+        }
+
+        for (var si = 0; si < chart.Series.Count; si++)
+        {
+            var series = chart.Series[si];
+            double[] ys;
+
+            if (cumulative is null)
+            {
+                ys = series.Values.ToArray();
+            }
+            else
+            {
+                ys = new double[catCount];
+                for (var i = 0; i < catCount; i++)
+                {
+                    if (double.IsNaN(series.Values[i]))
+                    {
+                        // Preserve gap; cumulative does not advance.
+                        ys[i] = double.NaN;
+                        continue;
+                    }
+
+                    var v = series.Values[i];
+                    if (totals is not null)
+                    {
+                        v = totals[i] > 0 ? v / totals[i] * 100 : 0;
+                    }
+
+                    cumulative[i] += v;
+                    ys[i] = cumulative[i];
+                }
+            }
+
+            var scatter = plt.Add.Scatter(xValues, ys);
+            scatter.Color = SeriesColor(si);
+            scatter.LineWidth = 2;
+            scatter.MarkerSize = 0;
+            scatter.LegendText = series.Name;
+        }
+
+        if (isDatetime)
+        {
+            plt.Axes.DateTimeTicksBottom();
+        }
+        else
+        {
+            plt.Axes.Bottom.SetTicks(
+                Enumerable.Range(0, catCount).Select(i => (double)i).ToArray(),
+                chart.Categories.ToArray());
+        }
+
+        if (chart.Series.Count > 1)
+        {
+            plt.Legend.IsVisible = true;
+        }
+
+        ClampYFloorToZeroIfNonNegative(plt, chart);
+    }
+
+    private static void AddBars(SP.Plot plt, QueryChartDefinition chart, bool horizontal)
+    {
+        if (chart.Series.Count == 0 || chart.Categories.Count == 0)
+        {
+            return;
+        }
+
+        var catCount = chart.Categories.Count;
+        var seriesCount = chart.Series.Count;
+        var isStacked = chart.Layout is QueryChartLayout.Stacked or QueryChartLayout.Stacked100;
+        var isStacked100 = chart.Layout == QueryChartLayout.Stacked100;
+
+        var totals = new double[catCount];
+        if (isStacked100)
+        {
+            foreach (var s in chart.Series)
+            {
+                for (var i = 0; i < catCount; i++)
+                {
+                    if (!double.IsNaN(s.Values[i]))
+                    {
+                        totals[i] += s.Values[i];
+                    }
+                }
+            }
+        }
+
+        if (isStacked)
+        {
+            var bottoms = new double[catCount];
+            for (var si = 0; si < seriesCount; si++)
+            {
+                var series = chart.Series[si];
+                var color = SeriesColor(si);
+                var bars = new List<SP.Bar>(catCount);
+                for (var i = 0; i < catCount; i++)
+                {
+                    if (double.IsNaN(series.Values[i]))
+                    {
+                        // Skip the bar entirely — leaves a visual gap and doesn't shift bottoms.
+                        continue;
+                    }
+
+                    var v = series.Values[i];
+                    if (isStacked100)
+                    {
+                        v = totals[i] > 0 ? v / totals[i] * 100 : 0;
+                    }
+
+                    bars.Add(new SP.Bar
+                    {
+                        Position = i,
+                        Value = bottoms[i] + v,
+                        ValueBase = bottoms[i],
+                        FillColor = color,
+                        Orientation = horizontal ? SP.Orientation.Horizontal : SP.Orientation.Vertical
+                    });
+                    bottoms[i] += v;
+                }
+
+                if (bars.Count > 0)
+                {
+                    var bp = plt.Add.Bars(bars);
+                    bp.LegendText = series.Name;
+                }
+            }
+        }
+        else
+        {
+            var groupWidth = 0.8;
+            var barWidth = seriesCount > 1 ? groupWidth / seriesCount : groupWidth;
+            var startOffset = seriesCount > 1 ? -groupWidth / 2.0 + barWidth / 2.0 : 0;
+
+            for (var si = 0; si < seriesCount; si++)
+            {
+                var series = chart.Series[si];
+                var color = SeriesColor(si);
+                var seriesOffset = startOffset + si * barWidth;
+                var bars = new List<SP.Bar>(catCount);
+                for (var i = 0; i < catCount; i++)
+                {
+                    if (double.IsNaN(series.Values[i]))
+                    {
+                        continue;
+                    }
+
+                    bars.Add(new SP.Bar
+                    {
+                        Position = i + seriesOffset,
+                        Value = series.Values[i],
+                        FillColor = color,
+                        Size = barWidth * 0.9,
+                        Orientation = horizontal ? SP.Orientation.Horizontal : SP.Orientation.Vertical
+                    });
+                }
+
+                if (bars.Count > 0)
+                {
+                    var bp = plt.Add.Bars(bars);
+                    bp.LegendText = series.Name;
+                }
+            }
+        }
+
+        var tickPositions = Enumerable.Range(0, catCount).Select(i => (double)i).ToArray();
+        var tickLabels = chart.Categories.ToArray();
+
+        if (horizontal)
+        {
+            plt.Axes.Left.SetTicks(tickPositions, tickLabels);
+        }
+        else
+        {
+            plt.Axes.Bottom.SetTicks(tickPositions, tickLabels);
+        }
+
+        if (seriesCount > 1)
+        {
+            plt.Legend.IsVisible = true;
+        }
+
+        if (isStacked100)
+        {
+            if (horizontal)
+            {
+                plt.Axes.SetLimitsX(0, 105);
+            }
+            else
+            {
+                plt.Axes.SetLimitsY(0, 105);
+            }
+        }
+        else
+        {
+            ClampYFloorToZeroIfNonNegative(plt, chart);
+        }
+    }
+
+    private static void ClampYFloorToZeroIfNonNegative(SP.Plot plt, QueryChartDefinition chart)
+    {
+        var allNonNegative = chart.Series
+            .SelectMany(s => s.Values)
+            .Where(v => !double.IsNaN(v))
+            .All(v => v >= 0);
+
+        if (!allNonNegative)
+        {
+            return;
+        }
+
+        plt.Axes.AutoScale();
+        var limits = plt.Axes.GetLimits();
+        if (limits.Bottom < 0)
+        {
+            plt.Axes.SetLimitsY(0, limits.Top);
+        }
+    }
+}

--- a/src/Kusto.Cli/Kusto.Cli.csproj
+++ b/src/Kusto.Cli/Kusto.Cli.csproj
@@ -26,6 +26,7 @@
     <PackageReference Include="Microsoft.Azure.Kusto.Language" Version="12.3.2" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.3" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.3" />
+    <PackageReference Include="ScottPlot" Version="5.1.58" />
     <PackageReference Include="System.CommandLine" Version="2.0.3" />
   </ItemGroup>
 

--- a/src/Kusto.Cli/KustoChartCompatibilityAnalyzer.cs
+++ b/src/Kusto.Cli/KustoChartCompatibilityAnalyzer.cs
@@ -112,7 +112,15 @@ internal static class KustoChartCompatibilityAnalyzer
         QueryChartKind kind,
         bool horizontal)
     {
-        var xColumn = ResolveColumnName(table, visualization.XColumn) ?? table.Columns.FirstOrDefault();
+        var xColumn = ResolveColumnName(table, visualization.XColumn);
+        if (xColumn == null)
+        {
+            // For timechart/linechart prefer a datetime column as X (the time bin is rarely first).
+            xColumn = kind == QueryChartKind.Line
+                ? FindDateTimeColumn(table) ?? table.Columns.FirstOrDefault()
+                : table.Columns.FirstOrDefault();
+        }
+
         if (string.IsNullOrWhiteSpace(xColumn))
         {
             return Unsupported(
@@ -121,6 +129,15 @@ internal static class KustoChartCompatibilityAnalyzer
         }
 
         var seriesColumns = ResolveSeriesColumns(table, visualization, xColumn);
+
+        // When Kusto returns long-format grouped data (e.g. summarize ... by DimCol, bin(time,5m))
+        // the Series field in the visualization may be unset. Auto-detect: any column that isn't
+        // the X column, isn't numeric and isn't a datetime is a series-split dimension.
+        if (seriesColumns.Count == 0)
+        {
+            seriesColumns = AutoDetectSeriesColumns(table, xColumn);
+        }
+
         var yColumns = ResolveYColumns(table, visualization, xColumn, seriesColumns);
         if (yColumns.Count == 0)
         {
@@ -153,6 +170,21 @@ internal static class KustoChartCompatibilityAnalyzer
             return Unsupported(cartesianResult.Reason, cartesianResult.Reason);
         }
 
+        DateTime[]? dateTimeCategories = null;
+        if (IsDateTimeColumn(table, xColumn) && cartesianResult.Categories is not null)
+        {
+            dateTimeCategories = ParseDateTimeCategories(cartesianResult.Categories);
+            if (dateTimeCategories is not null)
+            {
+                // Kusto may return rows in arbitrary order when grouping. Sort categories
+                // chronologically so lines connect adjacent time points instead of
+                // zig-zagging across the chart.
+                SortCategoriesChronologically(
+                    ref dateTimeCategories,
+                    ref cartesianResult);
+            }
+        }
+
         var definition = new QueryChartDefinition
         {
             Kind = kind,
@@ -162,7 +194,8 @@ internal static class KustoChartCompatibilityAnalyzer
             XTitle = visualization.XTitle,
             YTitle = visualization.YTitle,
             Categories = cartesianResult.Categories!,
-            Series = cartesianResult.Series!
+            Series = cartesianResult.Series!,
+            DateTimeCategories = dateTimeCategories
         };
 
         return new QueryChartCompatibility
@@ -301,15 +334,10 @@ internal static class KustoChartCompatibilityAnalyzer
         var series = new List<QueryChartSeries>(seriesMap.Count);
         foreach (var pair in seriesMap.OrderBy(pair => pair.Key, StringComparer.Ordinal))
         {
-            if (pair.Value.Count != categories.Count)
-            {
-                return (null, null, "The result contains missing X/series combinations that can't be charted faithfully.");
-            }
-
             var values = new double[categories.Count];
             for (var i = 0; i < values.Length; i++)
             {
-                values[i] = pair.Value[i];
+                values[i] = pair.Value.TryGetValue(i, out var v) ? v : double.NaN;
             }
 
             series.Add(new QueryChartSeries(pair.Key, values));
@@ -380,6 +408,293 @@ internal static class KustoChartCompatibilityAnalyzer
         return table.TryGetColumnIndex(requestedName, out var index)
             ? table.Columns[index]
             : null;
+    }
+
+    private static string? FindDateTimeColumn(TabularData table)
+    {
+        foreach (var column in table.Columns)
+        {
+            if (IsDateTimeColumn(table, column))
+            {
+                return column;
+            }
+        }
+
+        return null;
+    }
+
+    private static void SortCategoriesChronologically(
+        ref DateTime[] dateTimeCategories,
+        ref (IReadOnlyList<string>? Categories, IReadOnlyList<QueryChartSeries>? Series, string? Reason) cartesianResult)
+    {
+        var categories = cartesianResult.Categories!;
+        var series = cartesianResult.Series!;
+        var count = dateTimeCategories.Length;
+        var dates = dateTimeCategories;
+
+        // Build sort permutation: order[newIndex] = oldIndex
+        var order = new int[count];
+        for (var i = 0; i < count; i++)
+        {
+            order[i] = i;
+        }
+
+        Array.Sort(order, (a, b) => dates[a].CompareTo(dates[b]));
+
+        // If already sorted, nothing to do.
+        var alreadySorted = true;
+        for (var i = 0; i < count; i++)
+        {
+            if (order[i] != i)
+            {
+                alreadySorted = false;
+                break;
+            }
+        }
+
+        if (alreadySorted)
+        {
+            return;
+        }
+
+        var sortedDates = new DateTime[count];
+        var sortedCategories = new string[count];
+        for (var i = 0; i < count; i++)
+        {
+            sortedDates[i] = dateTimeCategories[order[i]];
+            sortedCategories[i] = categories[order[i]];
+        }
+
+        var sortedSeries = new List<QueryChartSeries>(series.Count);
+        foreach (var s in series)
+        {
+            var sortedValues = new double[count];
+            for (var i = 0; i < count; i++)
+            {
+                sortedValues[i] = s.Values[order[i]];
+            }
+
+            sortedSeries.Add(new QueryChartSeries(s.Name, sortedValues));
+        }
+
+        dateTimeCategories = sortedDates;
+        cartesianResult = (sortedCategories, sortedSeries, cartesianResult.Reason);
+    }
+
+    private static DateTime[]? ParseDateTimeCategories(IReadOnlyList<string> categories)
+    {
+        // Lenient: parse what we can. If at least one value parses, return the array
+        // with unparseable entries set to DateTime.MinValue so chronological sort still
+        // operates over the valid timestamps. If nothing parses, return null so the
+        // caller falls back to ordinal X axis.
+        var result = new DateTime[categories.Count];
+        var anyParsed = false;
+        for (var i = 0; i < categories.Count; i++)
+        {
+            if (DateTime.TryParse(
+                    categories[i],
+                    System.Globalization.CultureInfo.InvariantCulture,
+                    System.Globalization.DateTimeStyles.RoundtripKind,
+                    out result[i]))
+            {
+                anyParsed = true;
+            }
+            else
+            {
+                result[i] = DateTime.MinValue;
+            }
+        }
+
+        return anyParsed ? result : null;
+    }
+
+    private static IReadOnlyList<string> AutoDetectSeriesColumns(TabularData table, string xColumn)
+    {
+        // Phase 1: string/non-numeric, non-datetime columns are always grouping dimensions.
+        var obvious = table.Columns
+            .Where(column => !string.Equals(column, xColumn, StringComparison.OrdinalIgnoreCase))
+            .Where(column => !IsNumericColumn(table, column))
+            .Where(column => !IsDateTimeColumn(table, column))
+            .ToList();
+
+        if (obvious.Count > 0)
+        {
+            return obvious;
+        }
+
+        // Phase 2: numeric grouping dimensions (e.g. Status=0/1/2). Only attempt this if
+        // X values are duplicated (= long-format grouped data).
+        if (!table.TryGetColumnIndex(xColumn, out var xColIndex))
+        {
+            return obvious;
+        }
+
+        var uniqueXValues = new HashSet<string?>(table.Rows.Select(row => row[xColIndex]), StringComparer.Ordinal);
+        if (uniqueXValues.Count == table.Rows.Count)
+        {
+            // X is unique → wide format. All numeric columns are Y measurements.
+            return [];
+        }
+
+        var rowCount = table.Rows.Count;
+        var uniqueX = uniqueXValues.Count;
+
+        // Pre-compute candidates so we can apply structural checks.
+        var candidates = new List<(string Name, int Distinct, bool LooksLikeAggregate)>();
+        foreach (var column in table.Columns)
+        {
+            if (string.Equals(column, xColumn, StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            if (!IsNumericColumn(table, column))
+            {
+                continue;
+            }
+
+            if (!table.TryGetColumnIndex(column, out var colIdx))
+            {
+                continue;
+            }
+
+            // Use parsed-double cardinality so "0", " 0", "0.0" don't count as distinct.
+            var distinct = CountDistinctNumericValues(table, colIdx);
+            candidates.Add((column, distinct, LooksLikeAggregateColumn(column)));
+        }
+
+        if (candidates.Count == 0)
+        {
+            return [];
+        }
+
+        // Strong signal #1: aggregation-name pattern. A column named avg_Foo, sum_Bar,
+        // count_, dcount_, percentile_, AvgCpu, P50Cpu, etc. is virtually always a
+        // measurement, not a dimension. If at least one column matches the pattern,
+        // every aggregate-named column is a Y measurement, and every non-aggregate
+        // numeric column is a series-split.
+        if (candidates.Any(c => c.LooksLikeAggregate))
+        {
+            return candidates
+                .Where(c => !c.LooksLikeAggregate)
+                .Select(c => c.Name)
+                .ToList();
+        }
+
+        // Strong signal #2: structural fit. A series-split dimension D for long-format
+        // (X, D, Y) data should satisfy: distinct(X) * distinct(D) ≈ rowCount, i.e.
+        // each (X, D) combination appears about once. Allow ±20% slack for missing
+        // points. Pick the column with the cardinality that fits best.
+        var fitting = candidates
+            .Where(c => c.Distinct >= 2 && c.Distinct <= uniqueX)
+            .Select(c => new
+            {
+                c.Name,
+                c.Distinct,
+                Expected = (double)(uniqueX * c.Distinct),
+                Ratio = (double)rowCount / Math.Max(1, uniqueX * c.Distinct)
+            })
+            .Where(c => c.Ratio is >= 0.8 and <= 1.2)
+            .OrderBy(c => Math.Abs(c.Ratio - 1.0))
+            .ToList();
+
+        if (fitting.Count == 0)
+        {
+            // No column fits the long-format structure; treat all numeric as Y.
+            return [];
+        }
+
+        // Pick the single best-fitting series column. Multiple grouping dims would
+        // require Y-per-(D1,D2,...) which BuildGroupedSeries already handles, but
+        // auto-promoting more than one is risky — keep it conservative.
+        return [fitting[0].Name];
+    }
+
+    private static int CountDistinctNumericValues(TabularData table, int columnIndex)
+    {
+        var set = new HashSet<double>();
+        var sawNonNumeric = false;
+        foreach (var row in table.Rows)
+        {
+            if (columnIndex >= row.Count)
+            {
+                continue;
+            }
+
+            var raw = row[columnIndex];
+            if (string.IsNullOrWhiteSpace(raw))
+            {
+                continue;
+            }
+
+            if (double.TryParse(raw, System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture, out var v))
+            {
+                set.Add(v);
+            }
+            else
+            {
+                sawNonNumeric = true;
+            }
+        }
+
+        return sawNonNumeric ? set.Count + 1 : set.Count;
+    }
+
+    private static readonly System.Text.RegularExpressions.Regex AggregateColumnPattern =
+        new(@"^(avg|sum|count|dcount|min|max|stdev|stdevp|variance|variancep|percentile|p\d+|median|countif|sumif|avgif)([_A-Z]|$)",
+            System.Text.RegularExpressions.RegexOptions.IgnoreCase | System.Text.RegularExpressions.RegexOptions.Compiled);
+
+    private static bool LooksLikeAggregateColumn(string columnName)
+    {
+        if (string.IsNullOrWhiteSpace(columnName))
+        {
+            return false;
+        }
+
+        return AggregateColumnPattern.IsMatch(columnName);
+    }
+
+    private static bool IsDateTimeColumn(TabularData table, string columnName)
+    {
+        if (!table.TryGetColumnIndex(columnName, out var columnIndex))
+        {
+            return false;
+        }
+
+        // Lenient: a column counts as datetime if a strong majority (≥80%) of its
+        // non-empty values parse. A single corrupt row shouldn't disqualify the column.
+        var parsed = 0;
+        var nonEmpty = 0;
+        foreach (var row in table.Rows)
+        {
+            if (columnIndex >= row.Count)
+            {
+                continue;
+            }
+
+            var value = row[columnIndex];
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                continue;
+            }
+
+            nonEmpty++;
+            if (DateTime.TryParse(
+                    value,
+                    System.Globalization.CultureInfo.InvariantCulture,
+                    System.Globalization.DateTimeStyles.RoundtripKind,
+                    out _))
+            {
+                parsed++;
+            }
+        }
+
+        if (nonEmpty == 0)
+        {
+            return false;
+        }
+
+        return parsed * 5 >= nonEmpty * 4; // ≥80%
     }
 
     private static bool IsNumericColumn(TabularData table, string columnName)

--- a/src/Kusto.Cli/KustoChartCompatibilityAnalyzer.cs
+++ b/src/Kusto.Cli/KustoChartCompatibilityAnalyzer.cs
@@ -483,29 +483,20 @@ internal static class KustoChartCompatibilityAnalyzer
 
     private static DateTime[]? ParseDateTimeCategories(IReadOnlyList<string> categories)
     {
-        // Lenient: parse what we can. If at least one value parses, return the array
-        // with unparseable entries set to DateTime.MinValue so chronological sort still
-        // operates over the valid timestamps. If nothing parses, return null so the
-        // caller falls back to ordinal X axis.
         var result = new DateTime[categories.Count];
-        var anyParsed = false;
         for (var i = 0; i < categories.Count; i++)
         {
-            if (DateTime.TryParse(
+            if (!DateTime.TryParse(
                     categories[i],
                     System.Globalization.CultureInfo.InvariantCulture,
                     System.Globalization.DateTimeStyles.RoundtripKind,
                     out result[i]))
             {
-                anyParsed = true;
-            }
-            else
-            {
-                result[i] = DateTime.MinValue;
+                return null;
             }
         }
 
-        return anyParsed ? result : null;
+        return result;
     }
 
     private static IReadOnlyList<string> AutoDetectSeriesColumns(TabularData table, string xColumn)

--- a/src/Kusto.Cli/Models.cs
+++ b/src/Kusto.Cli/Models.cs
@@ -24,6 +24,8 @@ public sealed class CliOutput
     public string? HumanChartAnsi { get; init; }
     [JsonIgnore]
     public string? MarkdownChart { get; init; }
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? ChartOutputPath { get; init; }
     [JsonIgnore]
     public bool IsQueryResultTable { get; init; }
 }
@@ -303,6 +305,12 @@ internal sealed class QueryChartDefinition
     public string? YTitle { get; init; }
     public IReadOnlyList<string> Categories { get; init; } = [];
     public IReadOnlyList<QueryChartSeries> Series { get; init; } = [];
+
+    /// <summary>
+    /// When the X axis values are datetimes, this carries their parsed values so renderers
+    /// can use a proper DateTime axis instead of formatted strings.
+    /// </summary>
+    public DateTime[]? DateTimeCategories { get; init; }
 }
 
 internal sealed class QueryChartCompatibility

--- a/src/Kusto.Cli/OutputFormatter.cs
+++ b/src/Kusto.Cli/OutputFormatter.cs
@@ -37,6 +37,11 @@ public sealed class OutputFormatter : IOutputFormatter
             sections.Add(selectedChart);
         }
 
+        if (!string.IsNullOrWhiteSpace(output.ChartOutputPath))
+        {
+            sections.Add($"Chart written to {output.ChartOutputPath}");
+        }
+
         if (!string.IsNullOrWhiteSpace(output.WebExplorerUrl))
         {
             sections.Add(Hex1bHumanRenderer.RenderHyperlink("Open in Web Explorer", output.WebExplorerUrl, useAnsi));
@@ -106,6 +111,16 @@ public sealed class OutputFormatter : IOutputFormatter
             }
 
             buffer.AppendLine(output.MarkdownChart);
+        }
+
+        if (!string.IsNullOrWhiteSpace(output.ChartOutputPath))
+        {
+            if (buffer.Length > 0)
+            {
+                buffer.AppendLine();
+            }
+
+            buffer.AppendLine($"Chart written to {output.ChartOutputPath}");
         }
 
         if (!string.IsNullOrWhiteSpace(output.WebExplorerUrl))

--- a/tests/Kusto.Cli.Tests/ChartImageWriterTests.cs
+++ b/tests/Kusto.Cli.Tests/ChartImageWriterTests.cs
@@ -1,0 +1,139 @@
+namespace Kusto.Cli.Tests;
+
+public sealed class ChartImageWriterTests : IDisposable
+{
+    private readonly string _tempDir;
+
+    public ChartImageWriterTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "kusto-cli-tests-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            if (Directory.Exists(_tempDir))
+            {
+                Directory.Delete(_tempDir, recursive: true);
+            }
+        }
+        catch
+        {
+        }
+    }
+
+    private static QueryChartDefinition SampleChart() => new()
+    {
+        Kind = QueryChartKind.Column,
+        Title = "T",
+        Categories = ["a", "b"],
+        Series = [new QueryChartSeries("v", [1, 2])]
+    };
+
+    [Fact]
+    public async Task WritePngAsync_WritesFile_AndReturnsAbsolutePath()
+    {
+        var path = Path.Combine(_tempDir, "out.png");
+
+        var written = await ChartImageWriter.WritePngAsync(
+            SampleChart(),
+            path,
+            ChartStyle.DefaultWidth,
+            ChartStyle.DefaultHeight,
+            CancellationToken.None);
+
+        Assert.Equal(Path.GetFullPath(path), written);
+        Assert.True(File.Exists(written));
+        Assert.True(new FileInfo(written).Length > 100);
+        Assert.False(File.Exists(written + ".tmp"));
+    }
+
+    [Fact]
+    public async Task WritePngAsync_CreatesParentDirectory()
+    {
+        var nested = Path.Combine(_tempDir, "sub", "dir", "chart.png");
+
+        var written = await ChartImageWriter.WritePngAsync(
+            SampleChart(),
+            nested,
+            ChartStyle.DefaultWidth,
+            ChartStyle.DefaultHeight,
+            CancellationToken.None);
+
+        Assert.True(File.Exists(written));
+    }
+
+    [Fact]
+    public async Task WritePngAsync_NonPngExtension_Throws()
+    {
+        var path = Path.Combine(_tempDir, "out.jpg");
+
+        var ex = await Assert.ThrowsAsync<UserFacingException>(() => ChartImageWriter.WritePngAsync(
+            SampleChart(),
+            path,
+            ChartStyle.DefaultWidth,
+            ChartStyle.DefaultHeight,
+            CancellationToken.None));
+
+        Assert.Contains(".png", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task WritePngAsync_PathIsDirectory_Throws()
+    {
+        await Assert.ThrowsAsync<UserFacingException>(() => ChartImageWriter.WritePngAsync(
+            SampleChart(),
+            _tempDir,
+            ChartStyle.DefaultWidth,
+            ChartStyle.DefaultHeight,
+            CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task WritePngAsync_EmptyPath_Throws()
+    {
+        await Assert.ThrowsAsync<UserFacingException>(() => ChartImageWriter.WritePngAsync(
+            SampleChart(),
+            "",
+            ChartStyle.DefaultWidth,
+            ChartStyle.DefaultHeight,
+            CancellationToken.None));
+    }
+
+    [Theory]
+    [InlineData(50, 480)]
+    [InlineData(800, 50)]
+    [InlineData(99999, 480)]
+    [InlineData(800, 99999)]
+    public async Task WritePngAsync_DimensionOutOfRange_Throws(int width, int height)
+    {
+        var path = Path.Combine(_tempDir, "x.png");
+
+        await Assert.ThrowsAsync<UserFacingException>(() => ChartImageWriter.WritePngAsync(
+            SampleChart(),
+            path,
+            width,
+            height,
+            CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task WritePngAsync_OverwritesExistingFile()
+    {
+        var path = Path.Combine(_tempDir, "out.png");
+        await File.WriteAllBytesAsync(path, new byte[] { 0, 1, 2 });
+
+        var written = await ChartImageWriter.WritePngAsync(
+            SampleChart(),
+            path,
+            ChartStyle.DefaultWidth,
+            ChartStyle.DefaultHeight,
+            CancellationToken.None);
+
+        var bytes = await File.ReadAllBytesAsync(written);
+        Assert.True(bytes.Length > 100);
+        Assert.Equal(0x89, bytes[0]);
+    }
+}

--- a/tests/Kusto.Cli.Tests/ImageChartRendererTests.cs
+++ b/tests/Kusto.Cli.Tests/ImageChartRendererTests.cs
@@ -1,0 +1,118 @@
+using SkiaSharp;
+
+namespace Kusto.Cli.Tests;
+
+public sealed class ImageChartRendererTests
+{
+    private static readonly byte[] PngSignature = [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A];
+
+    [Theory]
+    [InlineData((int)QueryChartKind.Column, (int)QueryChartLayout.Simple, false)]
+    [InlineData((int)QueryChartKind.Column, (int)QueryChartLayout.Grouped, false)]
+    [InlineData((int)QueryChartKind.Column, (int)QueryChartLayout.Stacked, false)]
+    [InlineData((int)QueryChartKind.Column, (int)QueryChartLayout.Stacked100, false)]
+    [InlineData((int)QueryChartKind.Bar, (int)QueryChartLayout.Simple, true)]
+    [InlineData((int)QueryChartKind.Bar, (int)QueryChartLayout.Grouped, true)]
+    [InlineData((int)QueryChartKind.Bar, (int)QueryChartLayout.Stacked, true)]
+    [InlineData((int)QueryChartKind.Bar, (int)QueryChartLayout.Stacked100, true)]
+    [InlineData((int)QueryChartKind.Line, (int)QueryChartLayout.Simple, false)]
+    [InlineData((int)QueryChartKind.Line, (int)QueryChartLayout.Stacked, false)]
+    [InlineData((int)QueryChartKind.Line, (int)QueryChartLayout.Stacked100, false)]
+    public void RenderPng_CartesianKindAndLayout_ProducesValidPngWithRequestedDimensions(
+        int kindValue,
+        int layoutValue,
+        bool horizontal)
+    {
+        var kind = (QueryChartKind)kindValue;
+        var layout = (QueryChartLayout)layoutValue;
+
+        var chart = new QueryChartDefinition
+        {
+            Kind = kind,
+            Layout = layout,
+            Horizontal = horizontal,
+            Title = "Sample chart",
+            XTitle = "Categories",
+            YTitle = "Values",
+            Categories = ["alpha", "beta", "gamma", "delta"],
+            Series =
+            [
+                new QueryChartSeries("series-a", [10, 25, 15, 40]),
+                new QueryChartSeries("series-b", [5, 18, 12, 22])
+            ]
+        };
+
+        using var ms = new MemoryStream();
+        ImageChartRenderer.RenderPng(chart, 800, 480, ms);
+
+        AssertPng(ms, expectedWidth: 800, expectedHeight: 480);
+    }
+
+    [Fact]
+    public void RenderPng_PieChart_ProducesValidPng()
+    {
+        var chart = new QueryChartDefinition
+        {
+            Kind = QueryChartKind.Pie,
+            Title = "Distribution",
+            Categories = ["one", "two", "three", "four"],
+            Series = [new QueryChartSeries("share", [10, 20, 30, 40])]
+        };
+
+        using var ms = new MemoryStream();
+        ImageChartRenderer.RenderPng(chart, 1000, 600, ms);
+
+        AssertPng(ms, expectedWidth: 1000, expectedHeight: 600);
+    }
+
+    [Fact]
+    public void RenderPng_DefaultDimensions_ProducesValidPng()
+    {
+        var chart = new QueryChartDefinition
+        {
+            Kind = QueryChartKind.Column,
+            Title = "Default size",
+            Categories = ["a", "b"],
+            Series = [new QueryChartSeries("count", [3, 7])]
+        };
+
+        using var ms = new MemoryStream();
+        ImageChartRenderer.RenderPng(chart, ChartStyle.DefaultWidth, ChartStyle.DefaultHeight, ms);
+
+        AssertPng(ms, expectedWidth: ChartStyle.DefaultWidth, expectedHeight: ChartStyle.DefaultHeight);
+    }
+
+    [Fact]
+    public void RenderPng_DimensionsOutOfRange_Throws()
+    {
+        var chart = new QueryChartDefinition
+        {
+            Kind = QueryChartKind.Column,
+            Categories = ["a"],
+            Series = [new QueryChartSeries("v", [1])]
+        };
+
+        using var ms = new MemoryStream();
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => ImageChartRenderer.RenderPng(chart, 50, 480, ms));
+        Assert.Throws<ArgumentOutOfRangeException>(() => ImageChartRenderer.RenderPng(chart, 800, 50, ms));
+        Assert.Throws<ArgumentOutOfRangeException>(() => ImageChartRenderer.RenderPng(chart, 99999, 480, ms));
+    }
+
+    private static void AssertPng(MemoryStream stream, int expectedWidth, int expectedHeight)
+    {
+        Assert.True(stream.Length > 100, "PNG output suspiciously small");
+
+        var bytes = stream.ToArray();
+        for (var i = 0; i < PngSignature.Length; i++)
+        {
+            Assert.Equal(PngSignature[i], bytes[i]);
+        }
+
+        stream.Position = 0;
+        using var codec = SKCodec.Create(stream);
+        Assert.NotNull(codec);
+        Assert.Equal(expectedWidth, codec!.Info.Width);
+        Assert.Equal(expectedHeight, codec.Info.Height);
+    }
+}

--- a/tests/Kusto.Cli.Tests/KustoChartCompatibilityAnalyzerTests.cs
+++ b/tests/Kusto.Cli.Tests/KustoChartCompatibilityAnalyzerTests.cs
@@ -101,7 +101,7 @@ public sealed class KustoChartCompatibilityAnalyzerTests
     }
 
     [Fact]
-    public void Analyze_GroupedChartWithMissingSeriesPoint_IsRejected()
+    public void Analyze_GroupedChartWithMissingSeriesPoint_FillsWithNaN()
     {
         var table = new TabularData(
             ["Month", "Series", "Value"],
@@ -109,6 +109,7 @@ public sealed class KustoChartCompatibilityAnalyzerTests
                 ["Jan", "A", "1"],
                 ["Feb", "A", "2"],
                 ["Jan", "B", "3"]
+                // Feb/B is missing — should be filled with NaN
             ]);
         var visualization = new QueryVisualization
         {
@@ -120,9 +121,17 @@ public sealed class KustoChartCompatibilityAnalyzerTests
 
         var result = KustoChartCompatibilityAnalyzer.Analyze(table, visualization);
 
-        Assert.Null(result.HumanChart);
-        Assert.Null(result.MarkdownChart);
-        Assert.Contains("missing X/series combinations", result.HumanReason, StringComparison.OrdinalIgnoreCase);
+        Assert.NotNull(result.HumanChart);
+        Assert.Equal(2, result.HumanChart!.Categories.Count);
+        Assert.Equal(2, result.HumanChart.Series.Count);
+
+        var seriesA = result.HumanChart.Series.First(s => s.Name == "A");
+        var seriesB = result.HumanChart.Series.First(s => s.Name == "B");
+
+        Assert.Equal(1.0, seriesA.Values[0]); // Jan/A
+        Assert.Equal(2.0, seriesA.Values[1]); // Feb/A
+        Assert.Equal(3.0, seriesB.Values[0]); // Jan/B
+        Assert.True(double.IsNaN(seriesB.Values[1])); // Feb/B — missing, filled NaN
     }
 
     [Fact]
@@ -150,25 +159,180 @@ public sealed class KustoChartCompatibilityAnalyzerTests
     }
 
     [Fact]
-    public void Analyze_GroupedChart_WithCaseDistinctSeriesValues_KeepsSeriesSeparate()
+    public void Analyze_GroupedChart_WithNumericStatusAsSeriesColumn_DetectsStatusAsSeries()
     {
+        // Simulate: summarize avg(ExecutionTime) by Status, bin(PreciseTimeStamp, 5m) | render timechart
+        // Status is a low-cardinality integer (0, 1) — should be the series splitter, not a Y axis.
+        var t0 = new DateTime(2024, 1, 15, 10, 0, 0, DateTimeKind.Utc).ToString("o");
+        var t1 = new DateTime(2024, 1, 15, 10, 5, 0, DateTimeKind.Utc).ToString("o");
         var table = new TabularData(
-            ["Category", "Series", "Value"],
+            ["Status", "PreciseTimeStamp", "avg_ExecutionTime"],
             [
-                ["A", "X", "1"],
-                ["A", "x", "2"]
+                ["0", t0, "100"],
+                ["1", t0, "200"],
+                ["0", t1, "110"],
+                ["1", t1, "210"]
             ]);
-        var visualization = new QueryVisualization
-        {
-            Visualization = "columnchart",
-            XColumn = "Category",
-            Series = ["Series"],
-            YColumns = ["Value"]
-        };
+        var visualization = new QueryVisualization { Visualization = "timechart" };
 
         var result = KustoChartCompatibilityAnalyzer.Analyze(table, visualization);
 
         Assert.NotNull(result.HumanChart);
-        Assert.Equal(["X", "x"], result.HumanChart!.Series.Select(series => series.Name).ToArray());
+        // Two series — one per Status value
+        Assert.Equal(2, result.HumanChart!.Series.Count);
+        // Each series has 2 time points
+        Assert.All(result.HumanChart.Series, s => Assert.Equal(2, s.Values.Count));
+        // DateTime categories populated
+        Assert.NotNull(result.HumanChart.DateTimeCategories);
+    }
+
+    [Fact]
+    public void Analyze_WideFormatTimechart_NumericColumnsBecomeSeries()
+    {
+        // Wide format: summarize val1=sum(A), val2=sum(B) by bin(time, 5m) | render timechart
+        // X values are unique → both numeric columns are Y series, no series splitter.
+        var t0 = new DateTime(2024, 1, 15, 10, 0, 0, DateTimeKind.Utc).ToString("o");
+        var t1 = new DateTime(2024, 1, 15, 10, 5, 0, DateTimeKind.Utc).ToString("o");
+        var table = new TabularData(
+            ["PreciseTimeStamp", "val1", "val2"],
+            [
+                [t0, "10", "20"],
+                [t1, "11", "21"]
+            ]);
+        var visualization = new QueryVisualization { Visualization = "timechart" };
+
+        var result = KustoChartCompatibilityAnalyzer.Analyze(table, visualization);
+
+        Assert.NotNull(result.HumanChart);
+        Assert.Equal(2, result.HumanChart!.Series.Count);
+        Assert.Contains(result.HumanChart.Series, s => s.Name == "val1");
+        Assert.Contains(result.HumanChart.Series, s => s.Name == "val2");
+    }
+
+    [Fact]
+    public void Analyze_DateTimeXValues_AreSortedChronologically_WhenRowsAreOutOfOrder()
+    {
+        // Rows arrive out-of-order (e.g. grouped by Status first, then time).
+        var t0 = new DateTime(2024, 1, 15, 10, 0, 0, DateTimeKind.Utc);
+        var t1 = new DateTime(2024, 1, 15, 10, 5, 0, DateTimeKind.Utc);
+        var t2 = new DateTime(2024, 1, 15, 10, 10, 0, DateTimeKind.Utc);
+        var table = new TabularData(
+            ["Status", "PreciseTimeStamp", "avg_ExecutionTime"],
+            [
+                ["0", t2.ToString("o"), "12"],
+                ["0", t0.ToString("o"), "10"],
+                ["1", t1.ToString("o"), "21"],
+                ["0", t1.ToString("o"), "11"],
+                ["1", t0.ToString("o"), "20"],
+                ["1", t2.ToString("o"), "22"]
+            ]);
+        var visualization = new QueryVisualization { Visualization = "timechart" };
+
+        var result = KustoChartCompatibilityAnalyzer.Analyze(table, visualization);
+
+        Assert.NotNull(result.HumanChart);
+        Assert.NotNull(result.HumanChart!.DateTimeCategories);
+
+        var dates = result.HumanChart.DateTimeCategories!;
+        Assert.Equal(t0, dates[0]);
+        Assert.Equal(t1, dates[1]);
+        Assert.Equal(t2, dates[2]);
+
+        var series0 = result.HumanChart.Series.First(s => s.Name == "0");
+        Assert.Equal(10.0, series0.Values[0]);
+        Assert.Equal(11.0, series0.Values[1]);
+        Assert.Equal(12.0, series0.Values[2]);
+
+        var series1 = result.HumanChart.Series.First(s => s.Name == "1");
+        Assert.Equal(20.0, series1.Values[0]);
+        Assert.Equal(21.0, series1.Values[1]);
+        Assert.Equal(22.0, series1.Values[2]);
+    }
+
+    [Fact]
+    public void Analyze_LongFormat_WithAggregateNamedYColumn_KeepsAggregateAsY_AndPicksDimensionAsSeries()
+    {
+        // summarize AvgCpu = avg(CounterValue) by Status, bin(Time, 1m)
+        // Status is a low-cardinality int dimension; AvgCpu should remain Y, not be split.
+        var t0 = new DateTime(2024, 1, 15, 10, 0, 0, DateTimeKind.Utc).ToString("o");
+        var t1 = new DateTime(2024, 1, 15, 10, 1, 0, DateTimeKind.Utc).ToString("o");
+        var table = new TabularData(
+            ["Status", "Time", "AvgCpu"],
+            [
+                ["0", t0, "10.5"],
+                ["1", t0, "20.5"],
+                ["0", t1, "11.5"],
+                ["1", t1, "21.5"]
+            ]);
+        var visualization = new QueryVisualization { Visualization = "timechart" };
+
+        var result = KustoChartCompatibilityAnalyzer.Analyze(table, visualization);
+
+        Assert.NotNull(result.HumanChart);
+        // Two series, one per Status value; AvgCpu is the Y measurement.
+        Assert.Equal(2, result.HumanChart!.Series.Count);
+        Assert.Contains(result.HumanChart.Series, s => s.Name == "0");
+        Assert.Contains(result.HumanChart.Series, s => s.Name == "1");
+    }
+
+    [Fact]
+    public void Analyze_WideFormat_WithMultipleAggregateColumns_KeepsAllAsYSeries()
+    {
+        // summarize AvgCpu=avg(...), P50Cpu=percentile(...,50), P99Cpu=percentile(...,99) by bin(Time, 1m)
+        // Each numeric column is an aggregate measurement; none should be a series-split.
+        var t0 = new DateTime(2024, 1, 15, 10, 0, 0, DateTimeKind.Utc).ToString("o");
+        var t1 = new DateTime(2024, 1, 15, 10, 1, 0, DateTimeKind.Utc).ToString("o");
+        var t2 = new DateTime(2024, 1, 15, 10, 2, 0, DateTimeKind.Utc).ToString("o");
+        var table = new TabularData(
+            ["Time", "AvgCpu", "P50Cpu", "P99Cpu"],
+            [
+                [t0, "30.0", "29.0", "60.0"],
+                [t1, "31.5", "30.0", "61.0"],
+                [t2, "32.0", "31.0", "62.0"]
+            ]);
+        var visualization = new QueryVisualization { Visualization = "timechart" };
+
+        var result = KustoChartCompatibilityAnalyzer.Analyze(table, visualization);
+
+        Assert.NotNull(result.HumanChart);
+        Assert.Equal(3, result.HumanChart!.Series.Count);
+        Assert.Contains(result.HumanChart.Series, s => s.Name == "AvgCpu");
+        Assert.Contains(result.HumanChart.Series, s => s.Name == "P50Cpu");
+        Assert.Contains(result.HumanChart.Series, s => s.Name == "P99Cpu");
+    }
+
+    [Fact]
+    public void Analyze_DateTimeXValues_PartialParseFailures_StillSorts()
+    {
+        // One row out of five has a corrupt timestamp; remaining rows should still
+        // be detected as datetime and sorted chronologically.
+        var t0 = new DateTime(2024, 1, 15, 10, 0, 0, DateTimeKind.Utc).ToString("o");
+        var t1 = new DateTime(2024, 1, 15, 10, 5, 0, DateTimeKind.Utc).ToString("o");
+        var t2 = new DateTime(2024, 1, 15, 10, 10, 0, DateTimeKind.Utc).ToString("o");
+        var t3 = new DateTime(2024, 1, 15, 10, 15, 0, DateTimeKind.Utc).ToString("o");
+        var table = new TabularData(
+            ["Time", "AvgCpu"],
+            [
+                [t2, "12"],
+                [t0, "10"],
+                ["garbage", "99"],
+                [t3, "13"],
+                [t1, "11"]
+            ]);
+        var visualization = new QueryVisualization { Visualization = "timechart" };
+
+        var result = KustoChartCompatibilityAnalyzer.Analyze(table, visualization);
+
+        Assert.NotNull(result.HumanChart);
+        Assert.NotNull(result.HumanChart!.DateTimeCategories);
+        // 4 valid timestamps + 1 garbage = 5 entries
+        Assert.Equal(5, result.HumanChart.DateTimeCategories!.Length);
+        // Garbage parsed as MinValue should sort to position 0; valid timestamps
+        // sorted chronologically follow.
+        var dates = result.HumanChart.DateTimeCategories;
+        Assert.Equal(DateTime.MinValue, dates[0]);
+        Assert.True(dates[1] < dates[2]);
+        Assert.True(dates[2] < dates[3]);
+        Assert.True(dates[3] < dates[4]);
     }
 }

--- a/tests/Kusto.Cli.Tests/KustoChartCompatibilityAnalyzerTests.cs
+++ b/tests/Kusto.Cli.Tests/KustoChartCompatibilityAnalyzerTests.cs
@@ -302,10 +302,10 @@ public sealed class KustoChartCompatibilityAnalyzerTests
     }
 
     [Fact]
-    public void Analyze_DateTimeXValues_PartialParseFailures_StillSorts()
+    public void Analyze_DateTimeXValues_PartialParseFailures_FallsBackToOrdinalAxis()
     {
-        // One row out of five has a corrupt timestamp; remaining rows should still
-        // be detected as datetime and sorted chronologically.
+        // One row out of five has a corrupt timestamp; avoid substituting a bogus
+        // DateTime.MinValue point far outside the real data range.
         var t0 = new DateTime(2024, 1, 15, 10, 0, 0, DateTimeKind.Utc).ToString("o");
         var t1 = new DateTime(2024, 1, 15, 10, 5, 0, DateTimeKind.Utc).ToString("o");
         var t2 = new DateTime(2024, 1, 15, 10, 10, 0, DateTimeKind.Utc).ToString("o");
@@ -324,15 +324,7 @@ public sealed class KustoChartCompatibilityAnalyzerTests
         var result = KustoChartCompatibilityAnalyzer.Analyze(table, visualization);
 
         Assert.NotNull(result.HumanChart);
-        Assert.NotNull(result.HumanChart!.DateTimeCategories);
-        // 4 valid timestamps + 1 garbage = 5 entries
-        Assert.Equal(5, result.HumanChart.DateTimeCategories!.Length);
-        // Garbage parsed as MinValue should sort to position 0; valid timestamps
-        // sorted chronologically follow.
-        var dates = result.HumanChart.DateTimeCategories;
-        Assert.Equal(DateTime.MinValue, dates[0]);
-        Assert.True(dates[1] < dates[2]);
-        Assert.True(dates[2] < dates[3]);
-        Assert.True(dates[3] < dates[4]);
+        Assert.Null(result.HumanChart!.DateTimeCategories);
+        Assert.Equal([t2, t0, "garbage", t3, t1], result.HumanChart.Categories);
     }
 }

--- a/tests/Kusto.Cli.Tests/OutputFormatterTests.cs
+++ b/tests/Kusto.Cli.Tests/OutputFormatterTests.cs
@@ -283,6 +283,51 @@ public sealed class OutputFormatterTests
     }
 
     [Fact]
+    public void FormatHuman_QueryOutput_WithChartOutputPath_AppendsConfirmation()
+    {
+        var formatter = new OutputFormatter();
+        var output = new CliOutput
+        {
+            Table = new TabularData(["State", "Count"], [["TEXAS", "60"]]),
+            ChartOutputPath = "/tmp/chart.png"
+        };
+
+        var rendered = formatter.Format(output, OutputFormat.Human);
+
+        Assert.Contains("Chart written to /tmp/chart.png", rendered, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void FormatMarkdown_QueryOutput_WithChartOutputPath_AppendsConfirmation()
+    {
+        var formatter = new OutputFormatter();
+        var output = new CliOutput
+        {
+            Table = new TabularData(["State", "Count"], [["TEXAS", "60"]]),
+            ChartOutputPath = "/tmp/chart.png"
+        };
+
+        var rendered = formatter.Format(output, OutputFormat.Markdown);
+
+        Assert.Contains("Chart written to /tmp/chart.png", rendered, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void FormatJson_QueryOutput_WithChartOutputPath_IncludesField()
+    {
+        var formatter = new OutputFormatter();
+        var output = new CliOutput
+        {
+            ChartOutputPath = "/tmp/chart.png"
+        };
+
+        var rendered = formatter.Format(output, OutputFormat.Json);
+
+        Assert.Contains("\"chartOutputPath\"", rendered, StringComparison.Ordinal);
+        Assert.Contains("/tmp/chart.png", rendered, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void FormatHuman_QueryOutput_WithAnsiHumanChart_FallsBackToPlainChartWhenAnsiIsUnavailable()
     {
         var formatter = new OutputFormatter();

--- a/tests/Kusto.Cli.Tests/OutputFormatterTests.cs
+++ b/tests/Kusto.Cli.Tests/OutputFormatterTests.cs
@@ -328,6 +328,28 @@ public sealed class OutputFormatterTests
     }
 
     [Fact]
+    public void FormatCsv_WithChartOutputPath_PreservesTableOnStdout()
+    {
+        // CSV output is a data stream meant for redirection. The chart confirmation
+        // travels via stderr (handled by the command handler), not the formatter,
+        // so the formatter's CSV output for CSV+chart should look identical to plain CSV.
+        var formatter = new OutputFormatter();
+        var output = new CliOutput
+        {
+            Table = new TabularData(["State", "Count"], [["TEXAS", "60"], ["KANSAS", "40"]]),
+            ChartOutputPath = "/tmp/chart.png"
+        };
+
+        var rendered = formatter.Format(output, OutputFormat.Csv);
+
+        Assert.Contains("State,Count", rendered, StringComparison.Ordinal);
+        Assert.Contains("TEXAS,60", rendered, StringComparison.Ordinal);
+        Assert.Contains("KANSAS,40", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain("Chart written to", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain("/tmp/chart.png", rendered, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void FormatHuman_QueryOutput_WithAnsiHumanChart_FallsBackToPlainChartWhenAnsiIsUnavailable()
     {
         var formatter = new OutputFormatter();

--- a/tests/Kusto.Cli.Tests/QueryCommandTests.cs
+++ b/tests/Kusto.Cli.Tests/QueryCommandTests.cs
@@ -105,7 +105,56 @@ public sealed class QueryCommandTests
             Console.SetError(originalError);
         }
     }
+
+    [Fact]
+    public async Task Query_WithOutputChartWidth_WithoutOutputChart_ReturnsError()
+    {
+        var rootCommand = CommandFactory.CreateRootCommand();
+        var originalError = Console.Error;
+        using var errorWriter = new StringWriter();
+        Console.SetError(errorWriter);
+
+        try
+        {
+            var exitCode = await rootCommand.Parse(
+                    ["query", "print 1", "--output-chart-width", "1024"],
+                    new ParserConfiguration())
+                .InvokeAsync();
+
+            Assert.Equal(1, exitCode);
+            Assert.Contains("--output-chart", errorWriter.ToString(), StringComparison.Ordinal);
+        }
+        finally
+        {
+            Console.SetError(originalError);
+        }
+    }
+
+    [Fact]
+    public async Task Query_WithOutputChartHeight_WithoutOutputChart_ReturnsError()
+    {
+        var rootCommand = CommandFactory.CreateRootCommand();
+        var originalError = Console.Error;
+        using var errorWriter = new StringWriter();
+        Console.SetError(errorWriter);
+
+        try
+        {
+            var exitCode = await rootCommand.Parse(
+                    ["query", "print 1", "--output-chart-height", "600"],
+                    new ParserConfiguration())
+                .InvokeAsync();
+
+            Assert.Equal(1, exitCode);
+            Assert.Contains("--output-chart", errorWriter.ToString(), StringComparison.Ordinal);
+        }
+        finally
+        {
+            Console.SetError(originalError);
+        }
+    }
 }
 
 [CollectionDefinition("Console", DisableParallelization = true)]
 public sealed class ConsoleCollectionDefinition;
+


### PR DESCRIPTION
Modern LLMs are amazing at reading the temporal data directly from the charts. They can spot trends, patterns, peaks, plateaus and even things that we miss ourselves. Rather than producing tabular or text-based representation of graphs, it's far more powerful and economical to present a chart. The chart can have great resolution, and the cost is still the same (few hundred tokens).

In this PR, we cover the types of charts that are natively supported by Kusto Explorer / ADX itself.

Example:
```pwsh
@'
let startTime = ago(1h);
let endTime = now();
let _scaleUnit = "tfs-wus2-1";
macro-expand force_remote = true VsoUnion as regionalVsoDb (
    regionalVsoDb.CounterEvent
    | where PreciseTimeStamp between (startTime .. endTime)
    | where ScaleUnit == _scaleUnit
    | where Service == "tfs"
    | where DeploymentSlot == "Production"
    | where CounterName == @"\Processor(_Total)\% Processor Time"
    | project PreciseTimeStamp, RoleInstance, CounterValue
)
| summarize
    AvgCpu  = avg(CounterValue),
    P50Cpu  = percentile(CounterValue, 50),
    P99Cpu  = percentile(CounterValue, 99)
  by Time = bin(PreciseTimeStamp, 1m)
| order by Time asc
| render timechart with (title="CPU % - tfs-wus2-1", ytitle="CPU %")
'@ | dotnet run --project src\Kusto.Cli -- query - `
  --cluster cluster --database db`
  --output-chart .\cpu.png
```

Result
<img width="1200" height="675" alt="cpu" src="https://github.com/user-attachments/assets/a3b94902-f43a-47e2-b2a5-a3ee86d50263" />

