### PR TITLE
Add samples alias for examples command

### DIFF
--- a/src/Kusto.Cli/CommandFactory.cs
+++ b/src/Kusto.Cli/CommandFactory.cs
@@ -37,6 +37,7 @@ public static class CommandFactory
     {
         var examplesCommand = new Command("examples", "Show usage examples, aliases, and quick-start commands.");
         examplesCommand.Aliases.Add("example");
+        examplesCommand.Aliases.Add("samples");
         examplesCommand.Aliases.Add("aliases");
         examplesCommand.SetAction((parseResult, cancellationToken) =>
         {
@@ -57,7 +58,7 @@ public static class CommandFactory
                             ["Run KQL", "kusto query --format markdown --chart \"StormEvents | summarize Count=count() by State | top 5 by Count desc | render piechart\" --cluster help --database Samples"],
                             ["Run KQL", "kusto query \"StormEvents | summarize EventCount=count() by State | top 10 by EventCount desc\" --format csv --cluster help --database Samples > top-states.csv"],
                             ["Run KQL", "kusto query --file .\\queries\\top-states.kql --cluster help --database Samples"],
-                            ["Optional aliases", "aliases | clusters | db | databases | tables | ls | get | schema | rm | delete | use | run | exec | --db | --limit | -f"]
+                            ["Optional aliases", "aliases | samples | clusters | db | databases | tables | ls | get | schema | rm | delete | use | run | exec | --db | --limit | -f"]
                         ])
                 }), cancellationToken);
         });

--- a/tests/Kusto.Cli.Tests/ExamplesCommandTests.cs
+++ b/tests/Kusto.Cli.Tests/ExamplesCommandTests.cs
@@ -21,7 +21,7 @@ public sealed class ExamplesCommandTests
             Assert.Equal(0, exitCode);
             var output = outputWriter.ToString();
             Assert.Contains("Optional aliases", output, StringComparison.Ordinal);
-            Assert.Contains("samples", output, StringComparison.Ordinal);
+            Assert.Contains("aliases | samples", output, StringComparison.Ordinal);
         }
         finally
         {

--- a/tests/Kusto.Cli.Tests/ExamplesCommandTests.cs
+++ b/tests/Kusto.Cli.Tests/ExamplesCommandTests.cs
@@ -1,0 +1,31 @@
+using System.CommandLine;
+
+namespace Kusto.Cli.Tests;
+
+[Collection("Console")]
+public sealed class ExamplesCommandTests
+{
+    [Fact]
+    public async Task Examples_WithSamplesAlias_ShowsSamplesInOptionalAliases()
+    {
+        var rootCommand = CommandFactory.CreateRootCommand();
+        var originalOutput = Console.Out;
+        using var outputWriter = new StringWriter();
+        Console.SetOut(outputWriter);
+
+        try
+        {
+            var exitCode = await rootCommand.Parse(["samples"], new ParserConfiguration())
+                .InvokeAsync();
+
+            Assert.Equal(0, exitCode);
+            var output = outputWriter.ToString();
+            Assert.Contains("Optional aliases", output, StringComparison.Ordinal);
+            Assert.Contains("samples", output, StringComparison.Ordinal);
+        }
+        finally
+        {
+            Console.SetOut(originalOutput);
+        }
+    }
+}

--- a/tests/Kusto.Cli.Tests/ParserTests.cs
+++ b/tests/Kusto.Cli.Tests/ParserTests.cs
@@ -54,11 +54,13 @@ public sealed class ParserTests
         Assert.Empty(result.Errors);
     }
 
-    [Fact]
-    public void Parse_Examples_AcceptsAlias()
+    [Theory]
+    [InlineData("example")]
+    [InlineData("samples")]
+    public void Parse_Examples_AcceptsAlias(string alias)
     {
         var rootCommand = CommandFactory.CreateRootCommand();
-        var result = rootCommand.Parse(["example"], new ParserConfiguration());
+        var result = rootCommand.Parse([alias], new ParserConfiguration());
         Assert.Empty(result.Errors);
     }
 


### PR DESCRIPTION
Closes #66

Adds samples as an alias for kusto examples and includes it in the optional aliases output.